### PR TITLE
Add Node.js equivalent for Laravel models and schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+node-app/node_modules
 /public/build
 /public/hot
 /public/storage

--- a/node-app/README.md
+++ b/node-app/README.md
@@ -1,0 +1,49 @@
+# BloodVault Node.js Implementation
+
+This directory contains a Node.js translation of the Laravel models and database
+schema used by the BloodVault application. It replaces the Eloquent models and
+migration files with Sequelize equivalents and exposes a feature-complete
+Express application that demonstrates how the same behaviours can be achieved
+with a JavaScript stack.
+
+## What's included
+
+- **Sequelize models** for users, blood requests, blood donations, blood bank
+  inventory, and appointments with the same relationships, helper methods and
+  scopes that exist in the Laravel codebase.
+- **Migration scripts** that reproduce the database schema defined by the PHP
+  migrations.
+- **Express server** (`server.js`) that wires the models together with JWT based
+  authentication, Socket.IO real-time updates, Nodemailer powered email
+  notifications, and Agenda based job scheduling.
+- **Services** for sending transactional emails so that higher level features
+  can stay focused on business logic.
+
+To try the Node implementation:
+
+1. Install dependencies
+
+   ```bash
+   cd node-app
+   npm install
+   ```
+
+2. Configure environment variables (database credentials, SMTP settings, JWT
+   secret, etc.). You can copy the `.env.example` from the Laravel project or
+   create a new `.env` file in this directory.
+
+3. Run the development server
+
+   ```bash
+   npm run dev
+   ```
+
+   The API listens on port `4000` by default and exposes endpoints for
+   authentication, blood requests, donations, and appointments. Socket.IO
+   broadcasts appear under the `blood-*` and `appointment:*` event channels.
+
+4. Execute migrations with your preferred runner. If you install `sequelize-cli`
+   globally you can point it at `node-app/migrations` to rebuild the schema.
+
+This setup keeps the original PHP project intact while offering a reference
+implementation of the same domain logic using Node.js.

--- a/node-app/config/database.js
+++ b/node-app/config/database.js
@@ -1,0 +1,26 @@
+import { Sequelize } from 'sequelize';
+import dotenv from 'dotenv';
+
+// Load environment variables so the connection can be configured without
+// hard-coding secrets in source control. In a production deployment this file
+// expects values such as DB_HOST, DB_DATABASE, DB_USERNAME and DB_PASSWORD.
+dotenv.config();
+
+const database = process.env.DB_DATABASE || 'bloodvault';
+const username = process.env.DB_USERNAME || 'root';
+const password = process.env.DB_PASSWORD || '';
+const host = process.env.DB_HOST || '127.0.0.1';
+const dialect = process.env.DB_CONNECTION || 'mysql';
+
+export const sequelize = new Sequelize(database, username, password, {
+  host,
+  dialect,
+  logging: false,
+  define: {
+    underscored: false,
+    freezeTableName: true,
+    timestamps: true
+  }
+});
+
+export default sequelize;

--- a/node-app/migrations/001-create-users-table.js
+++ b/node-app/migrations/001-create-users-table.js
@@ -1,0 +1,87 @@
+/**
+ * Mirrors the Laravel migration 2025_08_17_034609_create_users_table.php
+ * and establishes the users table with the same column definitions.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('users', {
+    USER_ID: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    email: {
+      type: Sequelize.STRING(30),
+      allowNull: false,
+      unique: true
+    },
+    password: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    name: {
+      type: Sequelize.STRING(50),
+      allowNull: true
+    },
+    dob: {
+      type: Sequelize.STRING(10),
+      allowNull: true
+    },
+    sex: {
+      type: Sequelize.STRING(10),
+      allowNull: true
+    },
+    address: {
+      type: Sequelize.STRING(100),
+      allowNull: true
+    },
+    city: {
+      type: Sequelize.STRING(50),
+      allowNull: true
+    },
+    province: {
+      type: Sequelize.STRING(50),
+      allowNull: true
+    },
+    contact: {
+      type: Sequelize.STRING(11),
+      allowNull: true
+    },
+    bloodtype: {
+      type: Sequelize.STRING(4),
+      allowNull: true
+    },
+    usertype: {
+      type: Sequelize.STRING(30),
+      allowNull: true
+    },
+    schedule_date: {
+      type: Sequelize.STRING(10),
+      allowNull: true
+    },
+    last_donation_date: {
+      type: Sequelize.STRING(10),
+      allowNull: true
+    },
+    remember_token: {
+      type: Sequelize.STRING(100),
+      allowNull: true
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('users');
+}

--- a/node-app/migrations/002-add-email-verification-to-users.js
+++ b/node-app/migrations/002-add-email-verification-to-users.js
@@ -1,0 +1,28 @@
+/**
+ * Adds the email verification related columns mirroring
+ * 2025_08_17_050232_add_email_verification_to_users_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.addColumn('users', 'email_verified_at', {
+    type: Sequelize.DATE,
+    allowNull: true
+  });
+  await queryInterface.addColumn('users', 'email_verification_token', {
+    type: Sequelize.STRING(255),
+    allowNull: true,
+    unique: true
+  });
+  await queryInterface.addColumn('users', 'is_verified', {
+    type: Sequelize.BOOLEAN,
+    allowNull: false,
+    defaultValue: false
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.removeColumn('users', 'email_verified_at');
+  await queryInterface.removeColumn('users', 'email_verification_token');
+  await queryInterface.removeColumn('users', 'is_verified');
+}

--- a/node-app/migrations/003-create-screenings-table.js
+++ b/node-app/migrations/003-create-screenings-table.js
@@ -1,0 +1,41 @@
+/**
+ * Mirrors 2025_08_17_034701_create_screenings_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('screenings', {
+    SCREENING_ID: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    usertype: {
+      type: Sequelize.STRING(30),
+      allowNull: true
+    },
+    province: {
+      type: Sequelize.STRING(30),
+      allowNull: true
+    },
+    contact: {
+      type: Sequelize.STRING(30),
+      allowNull: true
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('screenings');
+}

--- a/node-app/migrations/004-create-requests-table.js
+++ b/node-app/migrations/004-create-requests-table.js
@@ -1,0 +1,51 @@
+/**
+ * Mirrors 2025_08_17_034727_create_requests_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('requests', {
+    RESERVATION_ID: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    request_date: {
+      type: Sequelize.STRING(6),
+      allowNull: true
+    },
+    required_blood: {
+      type: Sequelize.STRING(6),
+      allowNull: true
+    },
+    quantity: {
+      type: Sequelize.INTEGER,
+      allowNull: true
+    },
+    proof: {
+      type: Sequelize.BLOB,
+      allowNull: true
+    },
+    status: {
+      type: Sequelize.TINYINT,
+      allowNull: false,
+      defaultValue: 0,
+      comment: '-1 = denied, 0 = pending, 1 = approved'
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('requests');
+}

--- a/node-app/migrations/005-create-blood-banks-table.js
+++ b/node-app/migrations/005-create-blood-banks-table.js
@@ -1,0 +1,62 @@
+/**
+ * Mirrors 2025_08_17_034750_create_blood_banks_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('blood_banks', {
+    STOCK_ID: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    donor: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'USER_ID'
+      },
+      onDelete: 'CASCADE'
+    },
+    blood_type: {
+      type: Sequelize.STRING(10),
+      allowNull: true
+    },
+    acquisition_date: {
+      type: Sequelize.DATE,
+      allowNull: true
+    },
+    expiration_date: {
+      type: Sequelize.DATE,
+      allowNull: true
+    },
+    quantity: {
+      type: Sequelize.INTEGER,
+      allowNull: true
+    },
+    status: {
+      type: Sequelize.TINYINT,
+      allowNull: false,
+      defaultValue: 0,
+      comment: '-1 = denied, 0 = pending, 1 = approved'
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+  await queryInterface.addIndex('blood_banks', ['donor']);
+  await queryInterface.addIndex('blood_banks', ['blood_type']);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('blood_banks');
+}

--- a/node-app/migrations/006-create-blood-requests-table.js
+++ b/node-app/migrations/006-create-blood-requests-table.js
@@ -1,0 +1,99 @@
+/**
+ * Mirrors 2025_08_17_034801_create_blood_requests_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('blood_requests', {
+    id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    user_id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'USER_ID'
+      },
+      onDelete: 'CASCADE'
+    },
+    blood_type: {
+      type: Sequelize.STRING(5),
+      allowNull: false
+    },
+    units_needed: {
+      type: Sequelize.INTEGER,
+      allowNull: false
+    },
+    urgency: {
+      type: Sequelize.ENUM('low', 'medium', 'high', 'critical'),
+      allowNull: false,
+      defaultValue: 'medium'
+    },
+    reason: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    hospital: {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    },
+    contact_person: {
+      type: Sequelize.STRING(255),
+      allowNull: true
+    },
+    contact_number: {
+      type: Sequelize.STRING(20),
+      allowNull: true
+    },
+    request_date: {
+      type: Sequelize.DATE,
+      allowNull: false
+    },
+    status: {
+      type: Sequelize.ENUM('pending', 'approved', 'rejected', 'completed', 'cancelled'),
+      allowNull: false,
+      defaultValue: 'pending'
+    },
+    admin_notes: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    blood_available: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
+    allocated_units: {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      defaultValue: 0
+    },
+    additional_notes: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+  await queryInterface.addIndex('blood_requests', ['user_id']);
+  await queryInterface.addIndex('blood_requests', ['blood_type']);
+  await queryInterface.addIndex('blood_requests', ['status']);
+  await queryInterface.addIndex('blood_requests', ['urgency']);
+  await queryInterface.addIndex('blood_requests', ['request_date']);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('blood_requests');
+}

--- a/node-app/migrations/007-modify-allocated-units-on-blood-requests.js
+++ b/node-app/migrations/007-modify-allocated-units-on-blood-requests.js
@@ -1,0 +1,22 @@
+/**
+ * Mirrors 2025_08_17_112103_modify_allocated_units_nullable_in_blood_requests_table.php.
+ * The base table already matches the final structure, but this migration is kept
+ * to document the intent of the original schema change.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.changeColumn('blood_requests', 'allocated_units', {
+    type: Sequelize.INTEGER,
+    allowNull: true,
+    defaultValue: 0
+  });
+}
+
+export async function down(queryInterface, Sequelize) {
+  await queryInterface.changeColumn('blood_requests', 'allocated_units', {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: 0
+  });
+}

--- a/node-app/migrations/008-create-email-verifications-table.js
+++ b/node-app/migrations/008-create-email-verifications-table.js
@@ -1,0 +1,50 @@
+/**
+ * Mirrors 2025_08_17_034808_create_email_verifications_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('email_verifications', {
+    id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    email: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    token: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    expires_at: {
+      type: Sequelize.DATE,
+      allowNull: false
+    },
+    used: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+  await queryInterface.addIndex('email_verifications', ['email']);
+  await queryInterface.addIndex('email_verifications', ['token']);
+  await queryInterface.addIndex('email_verifications', ['expires_at']);
+  await queryInterface.addIndex('email_verifications', ['used']);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('email_verifications');
+}

--- a/node-app/migrations/009-create-blood-donations-table.js
+++ b/node-app/migrations/009-create-blood-donations-table.js
@@ -1,0 +1,72 @@
+/**
+ * Mirrors 2025_08_17_034816_create_blood_donations_table.php with the later
+ * additions from 2025_08_18_074142_add_missing_fields_to_blood_donations_table.php
+ * captured in a follow-up migration.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('blood_donations', {
+    id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    user_id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'USER_ID'
+      },
+      onDelete: 'CASCADE'
+    },
+    donor_name: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    donor_email: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    blood_type: {
+      type: Sequelize.STRING(10),
+      allowNull: false
+    },
+    donation_date: {
+      type: Sequelize.DATE,
+      allowNull: false
+    },
+    status: {
+      type: Sequelize.ENUM('pending', 'approved', 'completed', 'rejected'),
+      allowNull: false,
+      defaultValue: 'pending'
+    },
+    screening_answers: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    notes: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+  await queryInterface.addIndex('blood_donations', ['user_id']);
+  await queryInterface.addIndex('blood_donations', ['status']);
+  await queryInterface.addIndex('blood_donations', ['donation_date']);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('blood_donations');
+}

--- a/node-app/migrations/010-add-missing-fields-to-blood-donations.js
+++ b/node-app/migrations/010-add-missing-fields-to-blood-donations.js
@@ -1,0 +1,26 @@
+/**
+ * Mirrors 2025_08_18_074142_add_missing_fields_to_blood_donations_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.addColumn('blood_donations', 'admin_notes', {
+    type: Sequelize.TEXT,
+    allowNull: true
+  });
+  await queryInterface.addColumn('blood_donations', 'quantity', {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    defaultValue: 1
+  });
+  await queryInterface.addColumn('blood_donations', 'screening_status', {
+    type: Sequelize.STRING(50),
+    allowNull: true
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.removeColumn('blood_donations', 'admin_notes');
+  await queryInterface.removeColumn('blood_donations', 'quantity');
+  await queryInterface.removeColumn('blood_donations', 'screening_status');
+}

--- a/node-app/migrations/011-create-appointments-table.js
+++ b/node-app/migrations/011-create-appointments-table.js
@@ -1,0 +1,67 @@
+/**
+ * Mirrors 2025_08_17_034824_create_appointments_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('appointments', {
+    id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    user_id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'USER_ID'
+      },
+      onDelete: 'CASCADE'
+    },
+    appointment_type: {
+      type: Sequelize.STRING(50),
+      allowNull: false
+    },
+    appointment_date: {
+      type: Sequelize.DATE,
+      allowNull: false
+    },
+    time_slot: {
+      type: Sequelize.STRING(20),
+      allowNull: true
+    },
+    status: {
+      type: Sequelize.ENUM('pending', 'confirmed', 'cancelled', 'completed'),
+      allowNull: false,
+      defaultValue: 'pending'
+    },
+    notes: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    admin_notes: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+  await queryInterface.addIndex('appointments', ['user_id']);
+  await queryInterface.addIndex('appointments', ['appointment_date']);
+  await queryInterface.addIndex('appointments', ['status']);
+  await queryInterface.addIndex('appointments', ['appointment_type']);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('appointments');
+}

--- a/node-app/migrations/012-add-blood-type-to-appointments.js
+++ b/node-app/migrations/012-add-blood-type-to-appointments.js
@@ -1,0 +1,15 @@
+/**
+ * Mirrors 2025_08_17_055105_add_blood_type_to_appointments_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.addColumn('appointments', 'blood_type', {
+    type: Sequelize.STRING(4),
+    allowNull: true
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.removeColumn('appointments', 'blood_type');
+}

--- a/node-app/migrations/013-create-password-resets-table.js
+++ b/node-app/migrations/013-create-password-resets-table.js
@@ -1,0 +1,27 @@
+/**
+ * Mirrors 2014_10_12_100000_create_password_resets_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('password_resets', {
+    email: {
+      type: Sequelize.STRING(255),
+      allowNull: false,
+      primaryKey: true
+    },
+    token: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    created_at: {
+      type: Sequelize.DATE,
+      allowNull: true
+    }
+  });
+  await queryInterface.addIndex('password_resets', ['email']);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('password_resets');
+}

--- a/node-app/migrations/014-create-failed-jobs-table.js
+++ b/node-app/migrations/014-create-failed-jobs-table.js
@@ -1,0 +1,45 @@
+/**
+ * Mirrors 2019_08_19_000000_create_failed_jobs_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('failed_jobs', {
+    id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    uuid: {
+      type: Sequelize.STRING(255),
+      allowNull: false,
+      unique: true
+    },
+    connection: {
+      type: Sequelize.TEXT,
+      allowNull: false
+    },
+    queue: {
+      type: Sequelize.TEXT,
+      allowNull: false
+    },
+    payload: {
+      type: Sequelize.TEXT('long'),
+      allowNull: false
+    },
+    exception: {
+      type: Sequelize.TEXT('long'),
+      allowNull: false
+    },
+    failed_at: {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('failed_jobs');
+}

--- a/node-app/migrations/015-create-personal-access-tokens-table.js
+++ b/node-app/migrations/015-create-personal-access-tokens-table.js
@@ -1,0 +1,60 @@
+/**
+ * Mirrors 2019_12_14_000001_create_personal_access_tokens_table.php.
+ * @param {import('sequelize').QueryInterface} queryInterface
+ * @param {typeof import('sequelize').Sequelize} Sequelize
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('personal_access_tokens', {
+    id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    tokenable_type: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    tokenable_id: {
+      type: Sequelize.BIGINT.UNSIGNED,
+      allowNull: false
+    },
+    name: {
+      type: Sequelize.STRING(255),
+      allowNull: false
+    },
+    token: {
+      type: Sequelize.STRING(64),
+      allowNull: false,
+      unique: true
+    },
+    abilities: {
+      type: Sequelize.TEXT,
+      allowNull: true
+    },
+    last_used_at: {
+      type: Sequelize.DATE,
+      allowNull: true
+    },
+    expires_at: {
+      type: Sequelize.DATE,
+      allowNull: true
+    },
+    created_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    },
+    updated_at: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+    }
+  });
+  await queryInterface.addIndex('personal_access_tokens', ['tokenable_type', 'tokenable_id']);
+  await queryInterface.addIndex('personal_access_tokens', ['token']);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('personal_access_tokens');
+}

--- a/node-app/models/appointment.js
+++ b/node-app/models/appointment.js
@@ -1,0 +1,129 @@
+import { Model, DataTypes, Op, fn, col, literal } from 'sequelize';
+
+function isSameDay(dateA, dateB) {
+  return (
+    dateA.getFullYear() === dateB.getFullYear() &&
+    dateA.getMonth() === dateB.getMonth() &&
+    dateA.getDate() === dateB.getDate()
+  );
+}
+
+export class Appointment extends Model {
+  getStatusColor() {
+    switch (this.status) {
+      case 'pending':
+        return 'warning';
+      case 'confirmed':
+        return 'info';
+      case 'cancelled':
+        return 'danger';
+      case 'completed':
+        return 'success';
+      default:
+        return 'secondary';
+    }
+  }
+
+  isConfirmed() {
+    return this.status === 'confirmed';
+  }
+
+  isCancelled() {
+    return this.status === 'cancelled';
+  }
+
+  isToday() {
+    if (!this.appointmentDate) {
+      return false;
+    }
+    const appointmentDate = new Date(this.appointmentDate);
+    const today = new Date();
+    return isSameDay(appointmentDate, today);
+  }
+
+  isUpcoming() {
+    if (!this.appointmentDate) {
+      return false;
+    }
+    return new Date(this.appointmentDate) > new Date();
+  }
+
+  static initModel(sequelize) {
+    Appointment.init(
+      {
+        id: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          autoIncrement: true,
+          primaryKey: true
+        },
+        userId: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          allowNull: false,
+          field: 'user_id'
+        },
+        appointmentType: {
+          type: DataTypes.STRING(50),
+          allowNull: false,
+          field: 'appointment_type'
+        },
+        bloodType: {
+          type: DataTypes.STRING(4),
+          field: 'blood_type'
+        },
+        appointmentDate: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          field: 'appointment_date'
+        },
+        timeSlot: {
+          type: DataTypes.STRING(20),
+          field: 'time_slot'
+        },
+        status: {
+          type: DataTypes.ENUM('pending', 'confirmed', 'cancelled', 'completed'),
+          allowNull: false,
+          defaultValue: 'pending'
+        },
+        notes: {
+          type: DataTypes.TEXT
+        },
+        adminNotes: {
+          type: DataTypes.TEXT,
+          field: 'admin_notes'
+        }
+      },
+      {
+        sequelize,
+        tableName: 'appointments',
+        modelName: 'Appointment',
+        scopes: {
+          pending: { where: { status: 'pending' } },
+          confirmed: { where: { status: 'confirmed' } },
+          cancelled: { where: { status: 'cancelled' } },
+          completed: { where: { status: 'completed' } },
+          today: {
+            where: sequelize.where(fn('DATE', col('appointment_date')), '=', fn('CURDATE'))
+          },
+          upcoming: {
+            where: {
+              appointmentDate: {
+                [Op.gt]: literal('NOW()')
+              }
+            }
+          }
+        }
+      }
+    );
+    return Appointment;
+  }
+
+  static associate(models) {
+    Appointment.belongsTo(models.User, {
+      as: 'user',
+      foreignKey: 'userId',
+      targetKey: 'id'
+    });
+  }
+}
+
+export default Appointment;

--- a/node-app/models/bloodBank.js
+++ b/node-app/models/bloodBank.js
@@ -1,0 +1,110 @@
+import { Model, DataTypes, Op, literal } from 'sequelize';
+
+const STATUS_TEXT = {
+  1: 'Approved',
+  0: 'Pending',
+  '-1': 'Denied'
+};
+
+const STATUS_COLOR = {
+  1: 'success',
+  0: 'warning',
+  '-1': 'danger'
+};
+
+export class BloodBank extends Model {
+  isAvailable() {
+    return (
+      this.status === 1 &&
+      this.expirationDate &&
+      this.expirationDate > new Date() &&
+      this.quantity > 0
+    );
+  }
+
+  isExpired() {
+    return this.expirationDate ? this.expirationDate < new Date() : false;
+  }
+
+  isApproved() {
+    return this.status === 1;
+  }
+
+  getStatusText() {
+    return STATUS_TEXT[this.status] || 'Unknown';
+  }
+
+  getStatusColor() {
+    return STATUS_COLOR[this.status] || 'secondary';
+  }
+
+  static initModel(sequelize) {
+    BloodBank.init(
+      {
+        id: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          autoIncrement: true,
+          primaryKey: true,
+          field: 'STOCK_ID'
+        },
+        donorId: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          allowNull: false,
+          field: 'donor'
+        },
+        bloodType: {
+          type: DataTypes.STRING(10),
+          field: 'blood_type'
+        },
+        acquisitionDate: {
+          type: DataTypes.DATE,
+          field: 'acquisition_date'
+        },
+        expirationDate: {
+          type: DataTypes.DATE,
+          field: 'expiration_date'
+        },
+        quantity: {
+          type: DataTypes.INTEGER
+        },
+        status: {
+          type: DataTypes.TINYINT,
+          defaultValue: 0
+        }
+      },
+      {
+        sequelize,
+        tableName: 'blood_banks',
+        modelName: 'BloodBank',
+        scopes: {
+          approved: { where: { status: 1 } },
+          pending: { where: { status: 0 } },
+          denied: { where: { status: -1 } },
+          available: {
+            where: {
+              status: 1,
+              expirationDate: { [Op.gt]: literal('NOW()') },
+              quantity: { [Op.gt]: 0 }
+            }
+          },
+          expired: {
+            where: {
+              expirationDate: { [Op.lt]: literal('NOW()') }
+            }
+          }
+        }
+      }
+    );
+    return BloodBank;
+  }
+
+  static associate(models) {
+    BloodBank.belongsTo(models.User, {
+      as: 'donor',
+      foreignKey: 'donorId',
+      targetKey: 'id'
+    });
+  }
+}
+
+export default BloodBank;

--- a/node-app/models/bloodDonation.js
+++ b/node-app/models/bloodDonation.js
@@ -1,0 +1,160 @@
+import { Model, DataTypes } from 'sequelize';
+
+const COOLDOWN_DAYS = 56;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function addDays(date, days) {
+  return new Date(date.getTime() + days * DAY_IN_MS);
+}
+
+export class BloodDonation extends Model {
+  getStatusColor() {
+    switch (this.status) {
+      case 'pending':
+        return 'warning';
+      case 'approved':
+        return 'info';
+      case 'completed':
+        return 'success';
+      case 'rejected':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+
+  isEligible() {
+    return this.status === 'approved';
+  }
+
+  isCompleted() {
+    return this.status === 'completed';
+  }
+
+  static async canUserDonate(userId) {
+    const lastCompletedDonation = await this.findOne({
+      where: {
+        userId,
+        status: 'completed'
+      },
+      order: [['donationDate', 'DESC']]
+    });
+
+    if (!lastCompletedDonation) {
+      return true;
+    }
+
+    const nextEligibleDate = addDays(lastCompletedDonation.donationDate, COOLDOWN_DAYS);
+    return new Date() >= nextEligibleDate;
+  }
+
+  static async getNextEligibleDate(userId) {
+    const lastCompletedDonation = await this.findOne({
+      where: {
+        userId,
+        status: 'completed'
+      },
+      order: [['donationDate', 'DESC']]
+    });
+
+    if (!lastCompletedDonation) {
+      return null;
+    }
+
+    return addDays(lastCompletedDonation.donationDate, COOLDOWN_DAYS);
+  }
+
+  static async getRemainingCooldownDays(userId) {
+    const nextEligibleDate = await this.getNextEligibleDate(userId);
+    if (!nextEligibleDate) {
+      return 0;
+    }
+
+    const diff = Math.ceil((nextEligibleDate.getTime() - Date.now()) / DAY_IN_MS);
+    return Math.max(0, diff);
+  }
+
+  static initModel(sequelize) {
+    BloodDonation.init(
+      {
+        id: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          autoIncrement: true,
+          primaryKey: true
+        },
+        userId: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          allowNull: false,
+          field: 'user_id'
+        },
+        donorName: {
+          type: DataTypes.STRING(255),
+          allowNull: false,
+          field: 'donor_name'
+        },
+        donorEmail: {
+          type: DataTypes.STRING(255),
+          allowNull: false,
+          field: 'donor_email'
+        },
+        bloodType: {
+          type: DataTypes.STRING(10),
+          allowNull: false,
+          field: 'blood_type'
+        },
+        donationDate: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          field: 'donation_date'
+        },
+        quantity: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          defaultValue: 1
+        },
+        screeningStatus: {
+          type: DataTypes.STRING(50),
+          field: 'screening_status'
+        },
+        status: {
+          type: DataTypes.ENUM('pending', 'approved', 'completed', 'rejected'),
+          allowNull: false,
+          defaultValue: 'pending'
+        },
+        screeningAnswers: {
+          type: DataTypes.TEXT,
+          field: 'screening_answers'
+        },
+        notes: {
+          type: DataTypes.TEXT
+        },
+        adminNotes: {
+          type: DataTypes.TEXT,
+          field: 'admin_notes'
+        }
+      },
+      {
+        sequelize,
+        tableName: 'blood_donations',
+        modelName: 'BloodDonation',
+        scopes: {
+          pending: { where: { status: 'pending' } },
+          approved: { where: { status: 'approved' } },
+          completed: { where: { status: 'completed' } },
+          rejected: { where: { status: 'rejected' } }
+        }
+      }
+    );
+    return BloodDonation;
+  }
+
+  static associate(models) {
+    BloodDonation.belongsTo(models.User, {
+      as: 'user',
+      foreignKey: 'userId',
+      targetKey: 'id'
+    });
+  }
+}
+
+export default BloodDonation;

--- a/node-app/models/bloodRequest.js
+++ b/node-app/models/bloodRequest.js
@@ -1,0 +1,127 @@
+import { Model, DataTypes } from 'sequelize';
+
+const URGENCY_COLORS = {
+  critical: 'danger',
+  high: 'warning',
+  medium: 'info',
+  low: 'success'
+};
+
+const STATUS_COLORS = {
+  pending: 'warning',
+  approved: 'info',
+  rejected: 'danger',
+  completed: 'success',
+  cancelled: 'secondary'
+};
+
+export class BloodRequest extends Model {
+  getUrgencyColor() {
+    return URGENCY_COLORS[this.urgency] || 'secondary';
+  }
+
+  getStatusColor() {
+    return STATUS_COLORS[this.status] || 'secondary';
+  }
+
+  static initModel(sequelize) {
+    BloodRequest.init(
+      {
+        id: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          autoIncrement: true,
+          primaryKey: true
+        },
+        userId: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          allowNull: false,
+          field: 'user_id'
+        },
+        bloodType: {
+          type: DataTypes.STRING(5),
+          allowNull: false,
+          field: 'blood_type'
+        },
+        unitsNeeded: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          field: 'units_needed'
+        },
+        urgency: {
+          type: DataTypes.ENUM('low', 'medium', 'high', 'critical'),
+          allowNull: false,
+          defaultValue: 'medium'
+        },
+        reason: {
+          type: DataTypes.TEXT
+        },
+        hospital: {
+          type: DataTypes.STRING(255)
+        },
+        contactPerson: {
+          type: DataTypes.STRING(255),
+          field: 'contact_person'
+        },
+        contactNumber: {
+          type: DataTypes.STRING(20),
+          field: 'contact_number'
+        },
+        requestDate: {
+          type: DataTypes.DATE,
+          allowNull: false,
+          field: 'request_date'
+        },
+        status: {
+          type: DataTypes.ENUM('pending', 'approved', 'rejected', 'completed', 'cancelled'),
+          allowNull: false,
+          defaultValue: 'pending'
+        },
+        adminNotes: {
+          type: DataTypes.TEXT,
+          field: 'admin_notes'
+        },
+        bloodAvailable: {
+          type: DataTypes.BOOLEAN,
+          allowNull: false,
+          defaultValue: false,
+          field: 'blood_available'
+        },
+        allocatedUnits: {
+          type: DataTypes.INTEGER,
+          allowNull: true,
+          defaultValue: 0,
+          field: 'allocated_units'
+        },
+        additionalNotes: {
+          type: DataTypes.TEXT,
+          field: 'additional_notes'
+        }
+      },
+      {
+        sequelize,
+        tableName: 'blood_requests',
+        modelName: 'BloodRequest',
+        defaultScope: {
+          order: [['createdAt', 'DESC']]
+        },
+        scopes: {
+          pending: { where: { status: 'pending' } },
+          approved: { where: { status: 'approved' } },
+          critical: { where: { urgency: 'critical' } },
+          high: { where: { urgency: 'high' } }
+        }
+      }
+    );
+    return BloodRequest;
+  }
+
+  static associate(models) {
+    BloodRequest.belongsTo(models.User, {
+      as: 'user',
+      foreignKey: 'userId',
+      targetKey: 'id'
+    });
+  }
+}
+
+export default BloodRequest;

--- a/node-app/models/index.js
+++ b/node-app/models/index.js
@@ -1,0 +1,37 @@
+import sequelize from '../config/database.js';
+import User from './user.js';
+import BloodRequest from './bloodRequest.js';
+import BloodDonation from './bloodDonation.js';
+import Appointment from './appointment.js';
+import BloodBank from './bloodBank.js';
+
+let models = null;
+
+export function initModels() {
+  if (models) {
+    return models;
+  }
+
+  const initializedModels = {
+    User: User.initModel(sequelize),
+    BloodRequest: BloodRequest.initModel(sequelize),
+    BloodDonation: BloodDonation.initModel(sequelize),
+    Appointment: Appointment.initModel(sequelize),
+    BloodBank: BloodBank.initModel(sequelize)
+  };
+
+  Object.values(initializedModels).forEach((model) => {
+    if (typeof model.associate === 'function') {
+      model.associate(initializedModels);
+    }
+  });
+
+  models = initializedModels;
+  return models;
+}
+
+export function getModels() {
+  return initModels();
+}
+
+export default initModels();

--- a/node-app/models/user.js
+++ b/node-app/models/user.js
@@ -1,0 +1,158 @@
+import crypto from 'node:crypto';
+import { Model, DataTypes } from 'sequelize';
+
+/**
+ * Sequelize model that mirrors App\\Models\\User from Laravel.
+ */
+export class User extends Model {
+  isAdmin() {
+    return this.usertype === 'admin';
+  }
+
+  isDonor() {
+    return this.usertype === 'donor';
+  }
+
+  isRequester() {
+    return this.usertype === 'requester';
+  }
+
+  isEmailVerified() {
+    return this.emailVerifiedAt !== null;
+  }
+
+  async generateEmailVerificationToken() {
+    const token = crypto.randomBytes(32).toString('hex');
+    this.emailVerificationToken = token;
+    await this.save();
+    return token;
+  }
+
+  async markEmailAsVerified() {
+    this.emailVerifiedAt = new Date();
+    this.isVerified = true;
+    this.emailVerificationToken = null;
+    await this.save();
+  }
+
+  bloodRequests(options = {}) {
+    return this.getBloodRequests(options);
+  }
+
+  bloodDonations(options = {}) {
+    return this.getBloodDonations(options);
+  }
+
+  appointments(options = {}) {
+    return this.getAppointments(options);
+  }
+
+  static initModel(sequelize) {
+    User.init(
+      {
+        id: {
+          type: DataTypes.BIGINT.UNSIGNED,
+          autoIncrement: true,
+          primaryKey: true,
+          field: 'USER_ID'
+        },
+        email: {
+          type: DataTypes.STRING(30),
+          allowNull: false,
+          unique: true
+        },
+        password: {
+          type: DataTypes.STRING(255),
+          allowNull: false
+        },
+        name: {
+          type: DataTypes.STRING(50)
+        },
+        dob: {
+          type: DataTypes.STRING(10)
+        },
+        sex: {
+          type: DataTypes.STRING(10)
+        },
+        address: {
+          type: DataTypes.STRING(100)
+        },
+        city: {
+          type: DataTypes.STRING(50)
+        },
+        province: {
+          type: DataTypes.STRING(50)
+        },
+        contact: {
+          type: DataTypes.STRING(11)
+        },
+        bloodtype: {
+          type: DataTypes.STRING(4)
+        },
+        usertype: {
+          type: DataTypes.STRING(30)
+        },
+        scheduleDate: {
+          type: DataTypes.STRING(10),
+          field: 'schedule_date'
+        },
+        lastDonationDate: {
+          type: DataTypes.STRING(10),
+          field: 'last_donation_date'
+        },
+        rememberToken: {
+          type: DataTypes.STRING(100),
+          field: 'remember_token'
+        },
+        emailVerifiedAt: {
+          type: DataTypes.DATE,
+          field: 'email_verified_at'
+        },
+        emailVerificationToken: {
+          type: DataTypes.STRING(255),
+          field: 'email_verification_token'
+        },
+        isVerified: {
+          type: DataTypes.BOOLEAN,
+          field: 'is_verified',
+          defaultValue: false
+        }
+      },
+      {
+        sequelize,
+        tableName: 'users',
+        modelName: 'User',
+        underscored: false,
+        defaultScope: {
+          attributes: { exclude: ['password', 'rememberToken'] }
+        }
+      }
+    );
+    return User;
+  }
+
+  static associate(models) {
+    User.hasMany(models.BloodRequest, {
+      as: 'bloodRequests',
+      foreignKey: 'userId',
+      sourceKey: 'id'
+    });
+    User.hasMany(models.BloodDonation, {
+      as: 'bloodDonations',
+      foreignKey: 'userId',
+      sourceKey: 'id'
+    });
+    User.hasMany(models.Appointment, {
+      as: 'appointments',
+      foreignKey: 'userId',
+      sourceKey: 'id'
+    });
+    User.hasMany(models.BloodBank, {
+      as: 'bloodBankStock',
+      foreignKey: 'donorId',
+      sourceKey: 'id'
+    });
+  }
+}
+
+export default User;

--- a/node-app/package.json
+++ b/node-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bloodvault-node",
+  "version": "1.0.0",
+  "description": "Node.js equivalents of the BloodVault Laravel models and database schema.",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "dev": "node server.js",
+    "lint": "eslint .",
+    "start": "NODE_ENV=production node server.js"
+  },
+  "dependencies": {
+    "agenda": "^5.0.0",
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "mysql2": "^3.9.4",
+    "nodemailer": "^6.9.8",
+    "sequelize": "^6.37.1",
+    "socket.io": "^4.7.5"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0"
+  }
+}

--- a/node-app/server.js
+++ b/node-app/server.js
@@ -1,0 +1,407 @@
+import http from 'node:http';
+import express from 'express';
+import dotenv from 'dotenv';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { Server as SocketIOServer } from 'socket.io';
+import Agenda from 'agenda';
+
+import sequelize from './config/database.js';
+import { initModels, getModels } from './models/index.js';
+import {
+  sendRequestStatusUpdate,
+  sendDonationStatusUpdate,
+  sendAppointmentConfirmation,
+  sendAppointmentRejection,
+  sendAppointmentStatusUpdate
+} from './services/notificationService.js';
+import { sendMail } from './services/emailService.js';
+
+dotenv.config();
+
+const app = express();
+const server = http.createServer(app);
+const io = new SocketIOServer(server, {
+  cors: {
+    origin: '*'
+  }
+});
+
+app.use(express.json());
+
+const JWT_SECRET = process.env.JWT_SECRET || 'change-me';
+const PORT = Number(process.env.PORT || 4000);
+
+initModels();
+const models = getModels();
+const { User, BloodRequest, BloodDonation, Appointment, BloodBank } = models;
+
+const agenda = new Agenda({
+  db: { address: process.env.MONGO_URL || 'mongodb://127.0.0.1/bloodvault-jobs' },
+  processEvery: process.env.AGENDA_PROCESS_EVERY || '30 seconds'
+});
+
+agenda.define('send-email-verification', async (job) => {
+  const { userId, token } = job.attrs.data || {};
+  if (!userId || !token) {
+    return;
+  }
+
+  const user = await User.findByPk(userId);
+  if (!user || !user.email) {
+    return;
+  }
+
+  const verificationUrl = `${process.env.APP_URL || 'http://localhost:3000'}/verify-email?token=${token}`;
+  await sendMail({
+    to: user.email,
+    subject: 'Verify your BloodVault email address',
+    text: `Hello ${user.name || 'there'},\n\nPlease verify your email address by visiting ${verificationUrl}.\n\nThank you!`
+  });
+});
+
+agenda.define('broadcast-blood-availability', async () => {
+  const available = await BloodBank.scope('available').findAll({
+    attributes: ['id', 'bloodType', 'quantity', 'expirationDate']
+  });
+  io.emit('blood-bank:availability', available.map((record) => record.toJSON()));
+});
+
+agenda.define('remind-upcoming-appointments', async () => {
+  const upcoming = await Appointment.scope('upcoming').findAll({
+    limit: 10,
+    include: [{ model: User, as: 'user', attributes: ['email', 'name'] }]
+  });
+
+  await Promise.all(
+    upcoming.map(async (appointment) => {
+      if (!appointment.user?.email) {
+        return;
+      }
+
+      await sendMail({
+        to: appointment.user.email,
+        subject: 'Upcoming BloodVault appointment reminder',
+        text: `Hello ${appointment.user.name || 'there'},\n\n` +
+          `This is a reminder for your ${appointment.appointmentType} appointment on ` +
+          `${appointment.appointmentDate?.toISOString?.() || appointment.appointmentDate}.`
+      });
+    })
+  );
+});
+
+function authenticate(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header) {
+    return res.status(401).json({ message: 'Missing Authorization header' });
+  }
+
+  const token = header.replace(/^Bearer\s+/i, '');
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (error) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+app.post('/auth/register', async (req, res) => {
+  try {
+    const { email, password, name, usertype } = req.body;
+    const existing = await User.findOne({ where: { email } });
+    if (existing) {
+      return res.status(409).json({ message: 'Email already in use' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = await User.create({ email, password: hashedPassword, name, usertype });
+    const token = jwt.sign({ sub: user.id, role: user.usertype }, JWT_SECRET, { expiresIn: '1h' });
+
+    res.status(201).json({ id: user.id, email: user.email, token });
+  } catch (error) {
+    console.error('Registration failed', error);
+    res.status(500).json({ message: 'Registration failed' });
+  }
+});
+
+app.post('/auth/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.unscoped().findOne({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const token = jwt.sign({ sub: user.id, role: user.usertype }, JWT_SECRET, { expiresIn: '1h' });
+    res.json({ token, user: { id: user.id, email: user.email, name: user.name, usertype: user.usertype } });
+  } catch (error) {
+    console.error('Login failed', error);
+    res.status(500).json({ message: 'Login failed' });
+  }
+});
+
+app.post('/users/:id/request-email-verification', authenticate, async (req, res) => {
+  try {
+    const targetId = Number(req.params.id);
+    if (req.user.sub !== targetId && req.user.role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const user = await User.findByPk(targetId);
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    const token = await user.generateEmailVerificationToken();
+    await agenda.now('send-email-verification', { userId: user.id, token });
+
+    res.json({ message: 'Verification email scheduled' });
+  } catch (error) {
+    console.error('Failed to queue verification email', error);
+    res.status(500).json({ message: 'Failed to queue verification email' });
+  }
+});
+
+app.post('/users/verify-email', async (req, res) => {
+  try {
+    const { token } = req.body;
+    if (!token) {
+      return res.status(400).json({ message: 'Token is required' });
+    }
+
+    const user = await User.findOne({ where: { emailVerificationToken: token } });
+    if (!user) {
+      return res.status(400).json({ message: 'Invalid token' });
+    }
+
+    await user.markEmailAsVerified();
+    res.json({ message: 'Email verified' });
+  } catch (error) {
+    console.error('Email verification failed', error);
+    res.status(500).json({ message: 'Email verification failed' });
+  }
+});
+
+app.get('/users/:id/donation-eligibility', authenticate, async (req, res) => {
+  try {
+    const userId = Number(req.params.id);
+    if (req.user.sub !== userId && req.user.role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    const canDonate = await BloodDonation.canUserDonate(userId);
+    const nextEligibleDate = await BloodDonation.getNextEligibleDate(userId);
+    const remainingCooldown = await BloodDonation.getRemainingCooldownDays(userId);
+
+    res.json({ canDonate, nextEligibleDate, remainingCooldown });
+  } catch (error) {
+    console.error('Failed to calculate donation eligibility', error);
+    res.status(500).json({ message: 'Failed to calculate donation eligibility' });
+  }
+});
+
+app.post('/blood-requests', authenticate, async (req, res) => {
+  try {
+    const payload = {
+      userId: req.body.userId || req.user.sub,
+      bloodType: req.body.bloodType,
+      unitsNeeded: req.body.unitsNeeded,
+      urgency: req.body.urgency || 'medium',
+      reason: req.body.reason,
+      hospital: req.body.hospital,
+      contactPerson: req.body.contactPerson,
+      contactNumber: req.body.contactNumber,
+      requestDate: req.body.requestDate ? new Date(req.body.requestDate) : new Date(),
+      status: 'pending'
+    };
+
+    const bloodRequest = await BloodRequest.create(payload);
+    io.emit('blood-request:created', bloodRequest.toJSON());
+    res.status(201).json(bloodRequest);
+  } catch (error) {
+    console.error('Failed to create blood request', error);
+    res.status(500).json({ message: 'Failed to create blood request' });
+  }
+});
+
+app.patch('/blood-requests/:id/status', authenticate, async (req, res) => {
+  try {
+    const bloodRequest = await BloodRequest.findByPk(req.params.id, {
+      include: [{ model: User, as: 'user' }]
+    });
+
+    if (!bloodRequest) {
+      return res.status(404).json({ message: 'Request not found' });
+    }
+
+    if (req.body.status) {
+      bloodRequest.status = req.body.status;
+    }
+    if (typeof req.body.bloodAvailable === 'boolean') {
+      bloodRequest.bloodAvailable = req.body.bloodAvailable;
+    }
+    if (typeof req.body.allocatedUnits === 'number') {
+      bloodRequest.allocatedUnits = req.body.allocatedUnits;
+    }
+    if (req.body.adminNotes) {
+      bloodRequest.adminNotes = req.body.adminNotes;
+    }
+
+    await bloodRequest.save();
+    await sendRequestStatusUpdate(bloodRequest.id, bloodRequest.status, req.body.adminNotes);
+
+    io.emit('blood-request:updated', bloodRequest.toJSON());
+    res.json(bloodRequest);
+  } catch (error) {
+    console.error('Failed to update blood request', error);
+    res.status(500).json({ message: 'Failed to update blood request' });
+  }
+});
+
+app.post('/blood-donations', authenticate, async (req, res) => {
+  try {
+    const donation = await BloodDonation.create({
+      userId: req.body.userId || req.user.sub,
+      donorName: req.body.donorName,
+      donorEmail: req.body.donorEmail,
+      bloodType: req.body.bloodType,
+      donationDate: req.body.donationDate ? new Date(req.body.donationDate) : new Date(),
+      quantity: req.body.quantity || 1,
+      screeningStatus: req.body.screeningStatus,
+      screeningAnswers: req.body.screeningAnswers,
+      notes: req.body.notes
+    });
+
+    io.emit('blood-donation:created', donation.toJSON());
+    res.status(201).json(donation);
+  } catch (error) {
+    console.error('Failed to create blood donation', error);
+    res.status(500).json({ message: 'Failed to create blood donation' });
+  }
+});
+
+app.patch('/blood-donations/:id/status', authenticate, async (req, res) => {
+  try {
+    const donation = await BloodDonation.findByPk(req.params.id, {
+      include: [{ model: User, as: 'user' }]
+    });
+
+    if (!donation) {
+      return res.status(404).json({ message: 'Donation not found' });
+    }
+
+    if (req.body.status) {
+      donation.status = req.body.status;
+    }
+    if (req.body.screeningStatus) {
+      donation.screeningStatus = req.body.screeningStatus;
+    }
+    if (req.body.adminNotes) {
+      donation.adminNotes = req.body.adminNotes;
+    }
+
+    await donation.save();
+    await sendDonationStatusUpdate(donation.id, donation.status, req.body.adminNotes);
+
+    io.emit('blood-donation:updated', donation.toJSON());
+    res.json(donation);
+  } catch (error) {
+    console.error('Failed to update donation', error);
+    res.status(500).json({ message: 'Failed to update donation' });
+  }
+});
+
+app.post('/appointments', authenticate, async (req, res) => {
+  try {
+    const appointment = await Appointment.create({
+      userId: req.body.userId || req.user.sub,
+      appointmentType: req.body.appointmentType,
+      bloodType: req.body.bloodType,
+      appointmentDate: req.body.appointmentDate ? new Date(req.body.appointmentDate) : new Date(),
+      timeSlot: req.body.timeSlot,
+      notes: req.body.notes
+    });
+
+    io.emit('appointment:created', appointment.toJSON());
+    res.status(201).json(appointment);
+  } catch (error) {
+    console.error('Failed to create appointment', error);
+    res.status(500).json({ message: 'Failed to create appointment' });
+  }
+});
+
+app.patch('/appointments/:id/status', authenticate, async (req, res) => {
+  try {
+    const appointment = await Appointment.findByPk(req.params.id, {
+      include: [{ model: User, as: 'user' }]
+    });
+
+    if (!appointment) {
+      return res.status(404).json({ message: 'Appointment not found' });
+    }
+
+    if (req.body.status) {
+      appointment.status = req.body.status;
+    }
+    if (req.body.adminNotes) {
+      appointment.adminNotes = req.body.adminNotes;
+    }
+
+    await appointment.save();
+
+    if (appointment.status === 'confirmed') {
+      await sendAppointmentConfirmation(appointment.id);
+    } else if (appointment.status === 'cancelled') {
+      await sendAppointmentRejection(appointment.id, req.body.adminNotes);
+    } else {
+      await sendAppointmentStatusUpdate(appointment.id, appointment.status, req.body.adminNotes);
+    }
+
+    io.emit('appointment:updated', appointment.toJSON());
+    res.json(appointment);
+  } catch (error) {
+    console.error('Failed to update appointment', error);
+    res.status(500).json({ message: 'Failed to update appointment' });
+  }
+});
+
+io.on('connection', (socket) => {
+  console.log('Socket connected', socket.id);
+  socket.on('disconnect', () => console.log('Socket disconnected', socket.id));
+});
+
+async function bootstrap() {
+  try {
+    await sequelize.authenticate();
+    await agenda.start();
+    await agenda.every('1 hour', 'broadcast-blood-availability');
+    await agenda.every('1 day', 'remind-upcoming-appointments');
+
+    server.listen(PORT, () => {
+      console.log(`BloodVault Node API listening on port ${PORT}`);
+    });
+  } catch (error) {
+    console.error('Failed to start application', error);
+    process.exit(1);
+  }
+}
+
+bootstrap();
+
+process.on('SIGINT', async () => {
+  console.log('Shutting down gracefully...');
+  await agenda.stop();
+  server.close(() => process.exit(0));
+});
+
+export { app, server, io };

--- a/node-app/services/emailService.js
+++ b/node-app/services/emailService.js
@@ -1,0 +1,33 @@
+import nodemailer from 'nodemailer';
+
+const DEFAULT_FROM = process.env.MAIL_FROM_ADDRESS || 'no-reply@bloodvault.local';
+
+function createTransporter() {
+  if (process.env.MAIL_HOST) {
+    return nodemailer.createTransport({
+      host: process.env.MAIL_HOST,
+      port: Number(process.env.MAIL_PORT || 587),
+      secure: process.env.MAIL_ENCRYPTION === 'ssl',
+      auth: process.env.MAIL_USERNAME
+        ? {
+            user: process.env.MAIL_USERNAME,
+            pass: process.env.MAIL_PASSWORD
+          }
+        : undefined
+    });
+  }
+
+  return nodemailer.createTransport({
+    streamTransport: true,
+    newline: 'unix',
+    buffer: true
+  });
+}
+
+export const transporter = createTransporter();
+
+export async function sendMail({ to, subject, text, html, from = DEFAULT_FROM }) {
+  await transporter.sendMail({ from, to, subject, text, html });
+}
+
+export default { transporter, sendMail };

--- a/node-app/services/notificationService.js
+++ b/node-app/services/notificationService.js
@@ -1,0 +1,126 @@
+import { getModels } from '../models/index.js';
+import { sendMail } from './emailService.js';
+
+export async function sendRequestStatusUpdate(requestId, newStatus, adminNotes = '') {
+  const { BloodRequest, User } = getModels();
+  try {
+    const bloodRequest = await BloodRequest.findByPk(requestId, {
+      include: [{ model: User, as: 'user' }]
+    });
+
+    if (!bloodRequest || !bloodRequest.user || !bloodRequest.user.email) {
+      console.error(`User or email not found for blood request ID: ${requestId}`);
+      return false;
+    }
+
+    const subject = `Blood Request Status Update - ${newStatus}`;
+    const message = `Hello ${bloodRequest.user.name || 'donor'},\n\n` +
+      `Your blood request (${bloodRequest.bloodType}) for ${bloodRequest.unitsNeeded} unit(s) ` +
+      `submitted on ${bloodRequest.requestDate?.toISOString?.() || bloodRequest.requestDate} ` +
+      `has changed status from ${bloodRequest.status} to ${newStatus}.\n\n` +
+      (adminNotes ? `Admin notes: ${adminNotes}\n\n` : '') +
+      'Thank you for using BloodVault.';
+
+    await sendMail({ to: bloodRequest.user.email, subject, text: message });
+    console.info(`Request status update email sent to ${bloodRequest.user.email} for request ID: ${requestId}`);
+    return true;
+  } catch (error) {
+    console.error('Failed to send request status update email:', error);
+    return false;
+  }
+}
+
+export async function sendDonationStatusUpdate(donationId, newStatus, notes = '') {
+  const { BloodDonation, User } = getModels();
+  try {
+    const bloodDonation = await BloodDonation.findByPk(donationId, {
+      include: [{ model: User, as: 'user' }]
+    });
+
+    if (!bloodDonation || !bloodDonation.user || !bloodDonation.user.email) {
+      console.error(`User or email not found for blood donation ID: ${donationId}`);
+      return false;
+    }
+
+    const subject = `Blood Donation Status Update - ${newStatus}`;
+    const message = `Hello ${bloodDonation.user.name || 'donor'},\n\n` +
+      `Your blood donation (${bloodDonation.bloodType}) scheduled on ` +
+      `${bloodDonation.donationDate?.toISOString?.() || bloodDonation.donationDate} ` +
+      `has changed status from ${bloodDonation.status} to ${newStatus}.\n\n` +
+      (notes ? `Notes: ${notes}\n\n` : '') +
+      'Thank you for supporting our community.';
+
+    await sendMail({ to: bloodDonation.user.email, subject, text: message });
+    console.info(`Donation status update email sent to ${bloodDonation.user.email} for donation ID: ${donationId}`);
+    return true;
+  } catch (error) {
+    console.error('Failed to send donation status update email:', error);
+    return false;
+  }
+}
+
+export async function sendAppointmentConfirmation(appointmentId) {
+  return sendAppointmentNotification(appointmentId, 'Appointment Confirmed', (appointment) =>
+    `Hello ${appointment.user?.name || 'donor'},\n\n` +
+    `Your appointment for ${appointment.appointmentType} on ` +
+    `${appointment.appointmentDate?.toISOString?.() || appointment.appointmentDate}` +
+    `${appointment.timeSlot ? ` at ${appointment.timeSlot}` : ''} has been confirmed.\n\n` +
+    (appointment.notes ? `Notes: ${appointment.notes}\n\n` : '') +
+    'Thank you!'
+  );
+}
+
+export async function sendAppointmentRejection(appointmentId, adminNotes = '') {
+  return sendAppointmentNotification(appointmentId, 'Appointment Rejected', (appointment) =>
+    `Hello ${appointment.user?.name || 'donor'},\n\n` +
+    `Unfortunately your appointment for ${appointment.appointmentType} on ` +
+    `${appointment.appointmentDate?.toISOString?.() || appointment.appointmentDate}` +
+    `${appointment.timeSlot ? ` at ${appointment.timeSlot}` : ''} was rejected.\n\n` +
+    (adminNotes ? `Admin notes: ${adminNotes}\n\n` : '') +
+    'Please reach out to reschedule.'
+  );
+}
+
+export async function sendAppointmentStatusUpdate(appointmentId, newStatus, adminNotes = '') {
+  return sendAppointmentNotification(appointmentId, `Appointment Status Update - ${newStatus}`, (appointment) =>
+    `Hello ${appointment.user?.name || 'donor'},\n\n` +
+    `Your appointment for ${appointment.appointmentType} on ` +
+    `${appointment.appointmentDate?.toISOString?.() || appointment.appointmentDate}` +
+    `${appointment.timeSlot ? ` at ${appointment.timeSlot}` : ''} has changed status ` +
+    `from ${appointment.status} to ${newStatus}.\n\n` +
+    (adminNotes ? `Admin notes: ${adminNotes}\n\n` : '') +
+    'Thank you!'
+  );
+}
+
+async function sendAppointmentNotification(appointmentId, subjectPrefix, renderer) {
+  const { Appointment, User } = getModels();
+  try {
+    const appointment = await Appointment.findByPk(appointmentId, {
+      include: [{ model: User, as: 'user' }]
+    });
+
+    if (!appointment || !appointment.user || !appointment.user.email) {
+      console.error(`User or email not found for appointment ID: ${appointmentId}`);
+      return false;
+    }
+
+    const subject = `${subjectPrefix}${appointment.appointmentType ? ` - ${appointment.appointmentType}` : ''}`;
+    const message = renderer(appointment);
+
+    await sendMail({ to: appointment.user.email, subject, text: message });
+    console.info(`${subjectPrefix} email sent to ${appointment.user.email} for appointment ID: ${appointmentId}`);
+    return true;
+  } catch (error) {
+    console.error(`Failed to send appointment email for ID ${appointmentId}:`, error);
+    return false;
+  }
+}
+
+export default {
+  sendRequestStatusUpdate,
+  sendDonationStatusUpdate,
+  sendAppointmentConfirmation,
+  sendAppointmentRejection,
+  sendAppointmentStatusUpdate
+};


### PR DESCRIPTION
## Summary
- add a `node-app` workspace with Sequelize migrations that mirror the Laravel database schema
- port the Laravel Eloquent models and mailer service logic to Sequelize classes and a shared email service
- expose an Express/Socket.IO/Agenda powered API that recreates authentication, scheduling and notification flows
- document how to install and run the Node.js implementation

## Testing
- npm install --package-lock-only *(fails: npm registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf01d7b9788322a9b5ba679841496f