### PR TITLE
Replace PHP views with Node SPA and API

### DIFF
--- a/node-app/README.md
+++ b/node-app/README.md
@@ -16,6 +16,10 @@ with a JavaScript stack.
 - **Express server** (`server.js`) that wires the models together with JWT based
   authentication, Socket.IO real-time updates, Nodemailer powered email
   notifications, and Agenda based job scheduling.
+- **Static single-page portal** under `public/` that replaces the PHP Blade
+  views with a JavaScript dashboard. It consumes the Node API, surfaces the
+  key workflows (requests, donations, appointments, inventory, profile) and is
+  served directly by the Express app.
 - **Services** for sending transactional emails so that higher level features
   can stay focused on business logic.
 
@@ -38,9 +42,10 @@ To try the Node implementation:
    npm run dev
    ```
 
-   The API listens on port `4000` by default and exposes endpoints for
-   authentication, blood requests, donations, and appointments. Socket.IO
-   broadcasts appear under the `blood-*` and `appointment:*` event channels.
+   The API listens on port `4000` by default, exposes endpoints for
+   authentication, blood requests, donations, appointments and inventory, and
+   serves the dashboard UI at `/`. Socket.IO broadcasts appear under the
+   `blood-*` and `appointment:*` event channels.
 
 4. Execute migrations with your preferred runner. If you install `sequelize-cli`
    globally you can point it at `node-app/migrations` to rebuild the schema.

--- a/node-app/public/app.js
+++ b/node-app/public/app.js
@@ -1,0 +1,957 @@
+const API_BASE = '';
+
+const state = {
+  token: window.localStorage.getItem('bloodvault.token'),
+  user: null,
+  summary: null,
+  requests: [],
+  donations: [],
+  appointments: [],
+  inventory: []
+};
+
+const elements = {
+  authSection: document.getElementById('auth-section'),
+  appShell: document.getElementById('app-shell'),
+  logoutButton: document.getElementById('logout-button'),
+  statusBar: document.getElementById('status-bar'),
+  userName: document.getElementById('user-name'),
+  userRole: document.getElementById('user-role'),
+  userEmail: document.getElementById('user-email'),
+  summaryCards: document.getElementById('summary-cards'),
+  recentRequestsTable: document.getElementById('recent-requests-table'),
+  upcomingAppointmentsTable: document.getElementById('upcoming-appointments-table'),
+  requestsTable: document.getElementById('requests-table'),
+  donationsTable: document.getElementById('donations-table'),
+  appointmentsTable: document.getElementById('appointments-table'),
+  inventoryTable: document.getElementById('inventory-table'),
+  profileDetails: document.getElementById('profile-details'),
+  eligibilityPanel: document.getElementById('eligibility-panel'),
+  emptyRowTemplate: document.getElementById('empty-row-template')
+};
+
+const forms = {
+  login: document.getElementById('login-form'),
+  register: document.getElementById('register-form'),
+  request: document.getElementById('create-request-form'),
+  donation: document.getElementById('create-donation-form'),
+  appointment: document.getElementById('create-appointment-form')
+};
+
+const formErrors = {
+  login: document.getElementById('login-error'),
+  register: document.getElementById('register-error'),
+  request: document.getElementById('request-error'),
+  donation: document.getElementById('donation-error'),
+  appointment: document.getElementById('appointment-error')
+};
+
+const buttons = {
+  dashboardRefresh: document.getElementById('dashboard-refresh'),
+  refreshRequests: document.getElementById('refresh-requests'),
+  refreshDonations: document.getElementById('refresh-donations'),
+  refreshAppointments: document.getElementById('refresh-appointments'),
+  refreshInventory: document.getElementById('refresh-inventory'),
+  refreshProfile: document.getElementById('refresh-profile'),
+  refreshEligibility: document.getElementById('refresh-eligibility'),
+  requestVerification: document.getElementById('request-verification')
+};
+
+const formCards = {
+  request: document.getElementById('request-form-card'),
+  donation: document.getElementById('donation-form-card'),
+  appointment: document.getElementById('appointment-form-card')
+};
+
+let statusTimeoutId = null;
+
+function setToken(token) {
+  state.token = token;
+  if (token) {
+    window.localStorage.setItem('bloodvault.token', token);
+  } else {
+    window.localStorage.removeItem('bloodvault.token');
+  }
+}
+
+function showStatus(message, variant = 'info', timeout = 4000) {
+  if (!elements.statusBar) {
+    return;
+  }
+  elements.statusBar.textContent = message;
+  elements.statusBar.classList.remove('hidden', 'info', 'success', 'error');
+  elements.statusBar.classList.add(variant);
+  if (statusTimeoutId) {
+    window.clearTimeout(statusTimeoutId);
+  }
+  statusTimeoutId = window.setTimeout(() => {
+    elements.statusBar.classList.add('hidden');
+  }, timeout);
+}
+
+async function apiFetch(path, options = {}) {
+  const url = `${API_BASE}${path}`;
+  const fetchOptions = { ...options };
+  fetchOptions.headers = new Headers(options.headers || {});
+
+  if (state.token) {
+    fetchOptions.headers.set('Authorization', `Bearer ${state.token}`);
+  }
+
+  if (fetchOptions.body && !(fetchOptions.body instanceof FormData)) {
+    fetchOptions.headers.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(url, fetchOptions);
+  const contentType = response.headers.get('content-type') || '';
+  let payload = null;
+
+  if (contentType.includes('application/json')) {
+    payload = await response.json();
+  } else {
+    payload = await response.text();
+  }
+
+  if (!response.ok) {
+    const message = payload && typeof payload === 'object' && payload.message
+      ? payload.message
+      : typeof payload === 'string' && payload
+        ? payload
+        : `Request failed with status ${response.status}`;
+    const error = new Error(message);
+    error.status = response.status;
+    throw error;
+  }
+
+  return payload;
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function formatDateTime(value) {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function formatStatus(value) {
+  if (!value) {
+    return '—';
+  }
+  return value
+    .toString()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatRole(role) {
+  return formatStatus(role || '');
+}
+
+function showAuthShell(authenticated) {
+  if (authenticated) {
+    elements.authSection?.classList.add('hidden');
+    elements.appShell?.classList.remove('hidden');
+    elements.logoutButton?.classList.remove('hidden');
+  } else {
+    elements.authSection?.classList.remove('hidden');
+    elements.appShell?.classList.add('hidden');
+    elements.logoutButton?.classList.add('hidden');
+  }
+}
+
+function setActiveSection(name) {
+  const targetId = `${name}-section`;
+  document.querySelectorAll('.content-section').forEach((section) => {
+    section.classList.toggle('active', section.id === targetId);
+  });
+  document.querySelectorAll('.nav-link').forEach((link) => {
+    link.classList.toggle('active', link.dataset.section === name);
+  });
+}
+
+function updateUserSummary() {
+  if (!state.user) {
+    elements.userName.textContent = '';
+    elements.userRole.textContent = '';
+    elements.userEmail.textContent = '';
+    return;
+  }
+  elements.userName.textContent = state.user.name || state.user.email || `User #${state.user.id}`;
+  elements.userRole.textContent = formatRole(state.user.usertype);
+  elements.userEmail.textContent = state.user.email || '';
+}
+
+function updateFormPermissions() {
+  if (!state.user) {
+    return;
+  }
+  const role = state.user.usertype;
+  const isAdmin = role === 'admin';
+  const canRequest = isAdmin || role === 'requester';
+  const canDonate = isAdmin || role === 'donor';
+  const canAppointment = isAdmin || role === 'donor' || role === 'requester';
+
+  formCards.request?.classList.toggle('hidden', !canRequest);
+  formCards.donation?.classList.toggle('hidden', !canDonate);
+  formCards.appointment?.classList.toggle('hidden', !canAppointment);
+}
+
+async function refreshUser() {
+  if (!state.token) {
+    throw new Error('Missing authentication token.');
+  }
+  try {
+    const user = await apiFetch('/users/me');
+    state.user = user;
+    updateUserSummary();
+    updateFormPermissions();
+    return user;
+  } catch (error) {
+    if (error.status === 401) {
+      setToken(null);
+      showAuthShell(false);
+    }
+    throw error;
+  }
+}
+
+async function loadSummary() {
+  try {
+    const summary = await apiFetch('/dashboard/summary');
+    state.summary = summary;
+    renderSummary(summary);
+  } catch (error) {
+    console.error('Failed to load summary', error);
+    showStatus(error.message, 'error');
+  }
+}
+
+function renderSummary(summary) {
+  if (!summary) {
+    elements.summaryCards.innerHTML = '';
+    return;
+  }
+  const totals = summary.totals || {};
+  const summaryDefinitions = [
+    { key: 'requests', label: 'Total requests' },
+    { key: 'pendingRequests', label: 'Pending requests' },
+    { key: 'donations', label: 'Total donations' },
+    { key: 'completedDonations', label: 'Completed donations' },
+    { key: 'upcomingAppointments', label: 'Upcoming appointments' },
+    { key: 'availableUnits', label: 'Available units' }
+  ];
+
+  elements.summaryCards.innerHTML = '';
+  summaryDefinitions.forEach((item) => {
+    const card = document.createElement('div');
+    card.className = 'summary-card';
+    const value = document.createElement('strong');
+    value.textContent = typeof totals[item.key] === 'number' ? totals[item.key].toString() : '0';
+    const label = document.createElement('span');
+    label.textContent = item.label;
+    card.append(value, label);
+    elements.summaryCards.appendChild(card);
+  });
+
+  fillTable(elements.recentRequestsTable, summary.recentRequests || [], (request) => {
+    const row = document.createElement('tr');
+    row.append(
+      createCell(formatDate(request.requestDate)),
+      createCell(request.bloodType || '—'),
+      createCell(request.unitsNeeded ?? '—'),
+      createCell(formatStatus(request.status))
+    );
+    return row;
+  });
+
+  fillTable(elements.upcomingAppointmentsTable, summary.upcomingAppointments || [], (appointment) => {
+    const row = document.createElement('tr');
+    row.append(
+      createCell(formatDateTime(appointment.appointmentDate)),
+      createCell(appointment.appointmentType || '—'),
+      createCell(formatStatus(appointment.status))
+    );
+    return row;
+  });
+}
+
+async function loadRequests() {
+  try {
+    const requests = await apiFetch('/blood-requests');
+    state.requests = Array.isArray(requests) ? requests : [];
+    renderRequests();
+  } catch (error) {
+    console.error('Failed to load requests', error);
+    showStatus(error.message, 'error');
+  }
+}
+
+function renderRequests() {
+  const isAdmin = state.user?.usertype === 'admin';
+  fillTable(elements.requestsTable, state.requests, (request) => {
+    const row = document.createElement('tr');
+
+    row.append(
+      createCell(formatDateTime(request.requestDate)),
+      createCell(request.bloodType || '—'),
+      createCell(request.unitsNeeded ?? '—'),
+      createCell(formatStatus(request.urgency))
+    );
+
+    const statusCell = document.createElement('td');
+    let statusSelect = null;
+    if (isAdmin) {
+      statusSelect = document.createElement('select');
+      ['pending', 'approved', 'rejected', 'completed', 'cancelled'].forEach((status) => {
+        const option = document.createElement('option');
+        option.value = status;
+        option.textContent = formatStatus(status);
+        statusSelect.appendChild(option);
+      });
+      statusSelect.value = request.status || 'pending';
+      statusCell.appendChild(statusSelect);
+    } else {
+      statusCell.textContent = formatStatus(request.status);
+    }
+    row.appendChild(statusCell);
+
+    const availableCell = document.createElement('td');
+    let availableCheckbox = null;
+    if (isAdmin) {
+      availableCheckbox = document.createElement('input');
+      availableCheckbox.type = 'checkbox';
+      availableCheckbox.checked = Boolean(request.bloodAvailable);
+      availableCell.appendChild(availableCheckbox);
+    } else {
+      availableCell.textContent = request.bloodAvailable ? 'Yes' : 'No';
+    }
+    row.appendChild(availableCell);
+
+    const allocatedCell = document.createElement('td');
+    let allocatedInput = null;
+    if (isAdmin) {
+      allocatedInput = document.createElement('input');
+      allocatedInput.type = 'number';
+      allocatedInput.min = '0';
+      allocatedInput.value = request.allocatedUnits ?? 0;
+      allocatedInput.className = 'small-input';
+      allocatedCell.appendChild(allocatedInput);
+    } else {
+      allocatedCell.textContent = request.allocatedUnits ?? 0;
+    }
+    row.appendChild(allocatedCell);
+
+    const requesterCell = createCell(
+      request.user?.name || request.user?.email || (request.user ? `User #${request.user.id}` : '—')
+    );
+    row.appendChild(requesterCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions-cell';
+    if (isAdmin) {
+      const saveButton = document.createElement('button');
+      saveButton.type = 'button';
+      saveButton.className = 'button small primary';
+      saveButton.textContent = 'Save';
+      saveButton.addEventListener('click', async () => {
+        saveButton.disabled = true;
+        try {
+          await updateRequestStatus(request.id, {
+            status: statusSelect.value,
+            bloodAvailable: Boolean(availableCheckbox.checked),
+            allocatedUnits: Number.parseInt(allocatedInput.value, 10) || 0
+          });
+          showStatus('Request updated successfully.', 'success');
+          await loadRequests();
+        } catch (error) {
+          showStatus(error.message, 'error');
+        } finally {
+          saveButton.disabled = false;
+        }
+      });
+      actionsCell.appendChild(saveButton);
+    } else {
+      actionsCell.textContent = '—';
+    }
+    row.appendChild(actionsCell);
+
+    return row;
+  });
+}
+
+async function updateRequestStatus(id, payload) {
+  return apiFetch(`/blood-requests/${id}/status`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload)
+  });
+}
+
+async function loadDonations() {
+  try {
+    const donations = await apiFetch('/blood-donations');
+    state.donations = Array.isArray(donations) ? donations : [];
+    renderDonations();
+  } catch (error) {
+    console.error('Failed to load donations', error);
+    showStatus(error.message, 'error');
+  }
+}
+
+function renderDonations() {
+  const isAdmin = state.user?.usertype === 'admin';
+  fillTable(elements.donationsTable, state.donations, (donation) => {
+    const row = document.createElement('tr');
+    row.append(
+      createCell(formatDate(donation.donationDate)),
+      createCell(donation.bloodType || '—'),
+      createCell(donation.quantity ?? '—')
+    );
+
+    const statusCell = document.createElement('td');
+    let statusSelect = null;
+    if (isAdmin) {
+      statusSelect = document.createElement('select');
+      ['pending', 'approved', 'completed', 'rejected'].forEach((status) => {
+        const option = document.createElement('option');
+        option.value = status;
+        option.textContent = formatStatus(status);
+        statusSelect.appendChild(option);
+      });
+      statusSelect.value = donation.status || 'pending';
+      statusCell.appendChild(statusSelect);
+    } else {
+      statusCell.textContent = formatStatus(donation.status);
+    }
+    row.appendChild(statusCell);
+
+    const screeningCell = document.createElement('td');
+    let screeningInput = null;
+    if (isAdmin) {
+      screeningInput = document.createElement('input');
+      screeningInput.type = 'text';
+      screeningInput.value = donation.screeningStatus || '';
+      screeningCell.appendChild(screeningInput);
+    } else {
+      screeningCell.textContent = donation.screeningStatus || '—';
+    }
+    row.appendChild(screeningCell);
+
+    row.appendChild(
+      createCell(donation.user?.name || donation.donorName || donation.user?.email || '—')
+    );
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions-cell';
+    if (isAdmin) {
+      const saveButton = document.createElement('button');
+      saveButton.type = 'button';
+      saveButton.className = 'button small primary';
+      saveButton.textContent = 'Save';
+      saveButton.addEventListener('click', async () => {
+        saveButton.disabled = true;
+        try {
+          await updateDonationStatus(donation.id, {
+            status: statusSelect.value,
+            screeningStatus: screeningInput.value
+          });
+          showStatus('Donation updated successfully.', 'success');
+          await loadDonations();
+        } catch (error) {
+          showStatus(error.message, 'error');
+        } finally {
+          saveButton.disabled = false;
+        }
+      });
+      actionsCell.appendChild(saveButton);
+    } else {
+      actionsCell.textContent = '—';
+    }
+    row.appendChild(actionsCell);
+
+    return row;
+  });
+}
+
+async function updateDonationStatus(id, payload) {
+  return apiFetch(`/blood-donations/${id}/status`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload)
+  });
+}
+
+async function loadAppointments() {
+  try {
+    const appointments = await apiFetch('/appointments');
+    state.appointments = Array.isArray(appointments) ? appointments : [];
+    renderAppointments();
+  } catch (error) {
+    console.error('Failed to load appointments', error);
+    showStatus(error.message, 'error');
+  }
+}
+
+function renderAppointments() {
+  const isAdmin = state.user?.usertype === 'admin';
+  fillTable(elements.appointmentsTable, state.appointments, (appointment) => {
+    const row = document.createElement('tr');
+    row.append(
+      createCell(formatDateTime(appointment.appointmentDate)),
+      createCell(appointment.appointmentType || '—')
+    );
+
+    const statusCell = document.createElement('td');
+    let statusSelect = null;
+    if (isAdmin) {
+      statusSelect = document.createElement('select');
+      ['pending', 'confirmed', 'completed', 'cancelled'].forEach((status) => {
+        const option = document.createElement('option');
+        option.value = status;
+        option.textContent = formatStatus(status);
+        statusSelect.appendChild(option);
+      });
+      statusSelect.value = appointment.status || 'pending';
+      statusCell.appendChild(statusSelect);
+    } else {
+      statusCell.textContent = formatStatus(appointment.status);
+    }
+    row.appendChild(statusCell);
+
+    row.appendChild(createCell(appointment.notes || '—'));
+    row.appendChild(
+      createCell(
+        appointment.user?.name || appointment.user?.email || (appointment.user ? `User #${appointment.user.id}` : '—')
+      )
+    );
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions-cell';
+    if (isAdmin) {
+      const saveButton = document.createElement('button');
+      saveButton.type = 'button';
+      saveButton.className = 'button small primary';
+      saveButton.textContent = 'Save';
+      saveButton.addEventListener('click', async () => {
+        saveButton.disabled = true;
+        try {
+          await updateAppointmentStatus(appointment.id, { status: statusSelect.value });
+          showStatus('Appointment updated successfully.', 'success');
+          await loadAppointments();
+        } catch (error) {
+          showStatus(error.message, 'error');
+        } finally {
+          saveButton.disabled = false;
+        }
+      });
+      actionsCell.appendChild(saveButton);
+    } else {
+      actionsCell.textContent = '—';
+    }
+    row.appendChild(actionsCell);
+
+    return row;
+  });
+}
+
+async function updateAppointmentStatus(id, payload) {
+  return apiFetch(`/appointments/${id}/status`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload)
+  });
+}
+
+async function loadInventory() {
+  try {
+    const inventory = await apiFetch('/inventory');
+    state.inventory = Array.isArray(inventory) ? inventory : [];
+    renderInventory();
+  } catch (error) {
+    console.error('Failed to load inventory', error);
+    showStatus(error.message, 'error');
+  }
+}
+
+function renderInventory() {
+  const statusMap = {
+    1: 'Approved',
+    0: 'Pending',
+    '-1': 'Denied'
+  };
+  fillTable(elements.inventoryTable, state.inventory, (item) => {
+    const row = document.createElement('tr');
+    row.append(
+      createCell(item.bloodType || '—'),
+      createCell(item.quantity ?? '—'),
+      createCell(statusMap[item.status] || formatStatus(item.status)),
+      createCell(formatDate(item.expirationDate)),
+      createCell(item.donor?.name || item.donor?.email || (item.donor ? `User #${item.donor.id}` : '—'))
+    );
+    return row;
+  });
+}
+
+async function loadProfile() {
+  if (!state.user) {
+    elements.profileDetails.innerHTML = '';
+    return;
+  }
+  const user = state.user;
+  const profileEntries = [
+    ['Name', user.name || '—'],
+    ['Email', user.email || '—'],
+    ['Role', formatRole(user.usertype)],
+    ['Blood type', user.bloodtype || '—'],
+    ['City', user.city || '—'],
+    ['Province', user.province || '—'],
+    ['Contact', user.contact || '—'],
+    ['Address', user.address || '—'],
+    ['Email verified', user.emailVerifiedAt ? formatDateTime(user.emailVerifiedAt) : 'No']
+  ];
+
+  elements.profileDetails.innerHTML = '';
+  profileEntries.forEach(([label, value]) => {
+    const dt = document.createElement('dt');
+    dt.textContent = label;
+    const dd = document.createElement('dd');
+    dd.textContent = value;
+    elements.profileDetails.append(dt, dd);
+  });
+}
+
+function fillTable(tableElement, items, createRow) {
+  if (!tableElement) {
+    return;
+  }
+  const tbody = tableElement.querySelector('tbody');
+  tbody.innerHTML = '';
+  if (!items || items.length === 0) {
+    const fragment = elements.emptyRowTemplate.content.cloneNode(true);
+    const cell = fragment.querySelector('td');
+    const columnCount = tableElement.querySelectorAll('thead th').length || 1;
+    cell.setAttribute('colspan', columnCount);
+    tbody.appendChild(fragment);
+    return;
+  }
+  items.forEach((item) => {
+    const row = createRow(item);
+    tbody.appendChild(row);
+  });
+}
+
+function createCell(value) {
+  const cell = document.createElement('td');
+  cell.textContent = value ?? '—';
+  return cell;
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  if (!forms.login) {
+    return;
+  }
+  formErrors.login.classList.add('hidden');
+  const formData = new FormData(forms.login);
+  const payload = {
+    email: formData.get('email'),
+    password: formData.get('password')
+  };
+
+  try {
+    const data = await apiFetch('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    setToken(data.token);
+    showStatus('Welcome back!', 'success');
+    forms.login.reset();
+    await onAuthenticated(data.user || null);
+  } catch (error) {
+    formErrors.login.textContent = error.message;
+    formErrors.login.classList.remove('hidden');
+  }
+}
+
+async function handleRegister(event) {
+  event.preventDefault();
+  if (!forms.register) {
+    return;
+  }
+  formErrors.register.classList.add('hidden');
+  const formData = new FormData(forms.register);
+  const payload = {
+    name: formData.get('name'),
+    email: formData.get('email'),
+    password: formData.get('password'),
+    usertype: formData.get('usertype')
+  };
+
+  try {
+    const data = await apiFetch('/auth/register', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    setToken(data.token);
+    showStatus('Account created successfully.', 'success');
+    forms.register.reset();
+    await onAuthenticated();
+  } catch (error) {
+    formErrors.register.textContent = error.message;
+    formErrors.register.classList.remove('hidden');
+  }
+}
+
+async function handleCreateRequest(event) {
+  event.preventDefault();
+  if (!forms.request) {
+    return;
+  }
+  formErrors.request.classList.add('hidden');
+  const formData = new FormData(forms.request);
+  const payload = {
+    bloodType: formData.get('bloodType'),
+    unitsNeeded: Number.parseInt(formData.get('unitsNeeded'), 10) || 0,
+    urgency: formData.get('urgency'),
+    reason: formData.get('reason'),
+    hospital: formData.get('hospital'),
+    contactPerson: formData.get('contactPerson'),
+    contactNumber: formData.get('contactNumber'),
+    requestDate: formData.get('requestDate') || undefined
+  };
+
+  try {
+    await apiFetch('/blood-requests', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    forms.request.reset();
+    showStatus('Request submitted successfully.', 'success');
+    await loadRequests();
+    await loadSummary();
+  } catch (error) {
+    formErrors.request.textContent = error.message;
+    formErrors.request.classList.remove('hidden');
+  }
+}
+
+async function handleCreateDonation(event) {
+  event.preventDefault();
+  if (!forms.donation) {
+    return;
+  }
+  formErrors.donation.classList.add('hidden');
+  const formData = new FormData(forms.donation);
+  const payload = {
+    donorName: formData.get('donorName'),
+    donorEmail: formData.get('donorEmail'),
+    bloodType: formData.get('bloodType'),
+    donationDate: formData.get('donationDate') || undefined,
+    quantity: Number.parseInt(formData.get('quantity'), 10) || 1,
+    screeningStatus: formData.get('screeningStatus'),
+    notes: formData.get('notes')
+  };
+
+  try {
+    await apiFetch('/blood-donations', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    forms.donation.reset();
+    showStatus('Donation recorded successfully.', 'success');
+    await loadDonations();
+    await loadSummary();
+  } catch (error) {
+    formErrors.donation.textContent = error.message;
+    formErrors.donation.classList.remove('hidden');
+  }
+}
+
+async function handleCreateAppointment(event) {
+  event.preventDefault();
+  if (!forms.appointment) {
+    return;
+  }
+  formErrors.appointment.classList.add('hidden');
+  const formData = new FormData(forms.appointment);
+  const payload = {
+    appointmentType: formData.get('appointmentType'),
+    bloodType: formData.get('bloodType'),
+    appointmentDate: formData.get('appointmentDate'),
+    timeSlot: formData.get('timeSlot'),
+    notes: formData.get('notes')
+  };
+
+  try {
+    await apiFetch('/appointments', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    forms.appointment.reset();
+    showStatus('Appointment scheduled successfully.', 'success');
+    await loadAppointments();
+    await loadSummary();
+  } catch (error) {
+    formErrors.appointment.textContent = error.message;
+    formErrors.appointment.classList.remove('hidden');
+  }
+}
+
+async function refreshEligibility() {
+  if (!state.user) {
+    return;
+  }
+  try {
+    const eligibility = await apiFetch(`/users/${state.user.id}/donation-eligibility`);
+    elements.eligibilityPanel.classList.remove('hidden');
+    const { canDonate, nextEligibleDate, remainingCooldown } = eligibility;
+    const parts = [];
+    parts.push(canDonate ? 'You are eligible to donate.' : 'You are currently not eligible to donate.');
+    if (nextEligibleDate) {
+      parts.push(`Next eligible date: ${formatDate(nextEligibleDate)}.`);
+    }
+    if (typeof remainingCooldown === 'number' && remainingCooldown > 0) {
+      parts.push(`Days remaining in cooldown: ${remainingCooldown}.`);
+    }
+    elements.eligibilityPanel.textContent = parts.join(' ');
+  } catch (error) {
+    showStatus(error.message, 'error');
+  }
+}
+
+async function requestVerificationEmail() {
+  if (!state.user) {
+    return;
+  }
+  try {
+    await apiFetch(`/users/${state.user.id}/request-email-verification`, { method: 'POST' });
+    showStatus('Verification email requested.', 'success');
+  } catch (error) {
+    showStatus(error.message, 'error');
+  }
+}
+
+async function onAuthenticated(initialUser = null) {
+  if (initialUser) {
+    state.user = initialUser;
+  }
+  try {
+    await refreshUser();
+    showAuthShell(true);
+    setActiveSection('dashboard');
+    await Promise.all([
+      loadSummary(),
+      loadRequests(),
+      loadDonations(),
+      loadAppointments(),
+      loadInventory()
+    ]);
+    await loadProfile();
+  } catch (error) {
+    console.error('Failed to complete authentication flow', error);
+    showStatus(error.message, 'error');
+  }
+}
+
+function logout() {
+  setToken(null);
+  state.user = null;
+  state.summary = null;
+  state.requests = [];
+  state.donations = [];
+  state.appointments = [];
+  state.inventory = [];
+  showAuthShell(false);
+  elements.summaryCards.innerHTML = '';
+  fillTable(elements.recentRequestsTable, [], () => document.createElement('tr'));
+  fillTable(elements.upcomingAppointmentsTable, [], () => document.createElement('tr'));
+  fillTable(elements.requestsTable, [], () => document.createElement('tr'));
+  fillTable(elements.donationsTable, [], () => document.createElement('tr'));
+  fillTable(elements.appointmentsTable, [], () => document.createElement('tr'));
+  fillTable(elements.inventoryTable, [], () => document.createElement('tr'));
+  elements.profileDetails.innerHTML = '';
+  elements.eligibilityPanel.classList.add('hidden');
+  showStatus('You have been logged out.', 'info');
+}
+
+function initTabs() {
+  const tabButtons = document.querySelectorAll('.tab-button');
+  tabButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.tab;
+      tabButtons.forEach((btn) => {
+        const isActive = btn === button;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-selected', String(isActive));
+        const tabContent = document.getElementById(`${btn.dataset.tab}-tab`);
+        tabContent?.classList.toggle('active', isActive);
+        tabContent?.setAttribute('aria-hidden', String(!isActive));
+      });
+    });
+  });
+}
+
+function initNavigation() {
+  document.querySelectorAll('.nav-link').forEach((link) => {
+    link.addEventListener('click', () => {
+      setActiveSection(link.dataset.section);
+    });
+  });
+}
+
+function initForms() {
+  forms.login?.addEventListener('submit', handleLogin);
+  forms.register?.addEventListener('submit', handleRegister);
+  forms.request?.addEventListener('submit', handleCreateRequest);
+  forms.donation?.addEventListener('submit', handleCreateDonation);
+  forms.appointment?.addEventListener('submit', handleCreateAppointment);
+}
+
+function initButtons() {
+  elements.logoutButton?.addEventListener('click', logout);
+  buttons.dashboardRefresh?.addEventListener('click', loadSummary);
+  buttons.refreshRequests?.addEventListener('click', loadRequests);
+  buttons.refreshDonations?.addEventListener('click', loadDonations);
+  buttons.refreshAppointments?.addEventListener('click', loadAppointments);
+  buttons.refreshInventory?.addEventListener('click', loadInventory);
+  buttons.refreshProfile?.addEventListener('click', async () => {
+    try {
+      await refreshUser();
+      await loadProfile();
+    } catch (error) {
+      showStatus(error.message, 'error');
+    }
+  });
+  buttons.refreshEligibility?.addEventListener('click', refreshEligibility);
+  buttons.requestVerification?.addEventListener('click', requestVerificationEmail);
+}
+
+function init() {
+  initTabs();
+  initNavigation();
+  initForms();
+  initButtons();
+
+  if (state.token) {
+    onAuthenticated().catch((error) => {
+      console.error('Failed to restore session', error);
+      logout();
+    });
+  } else {
+    showAuthShell(false);
+  }
+}
+
+init();

--- a/node-app/public/index.html
+++ b/node-app/public/index.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BloodVault Portal</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="brand">
+        <span class="logo" aria-hidden="true">🩸</span>
+        <h1>BloodVault Portal</h1>
+      </div>
+      <button id="logout-button" class="button button-outline hidden">Log out</button>
+    </header>
+
+    <main class="main-container">
+      <section id="auth-section" class="auth card">
+        <div class="tabs" role="tablist">
+          <button class="tab-button active" data-tab="login" aria-selected="true">Login</button>
+          <button class="tab-button" data-tab="register" aria-selected="false">Register</button>
+        </div>
+        <div class="tab-content active" id="login-tab" role="tabpanel">
+          <form id="login-form" class="form-grid">
+            <label>
+              Email
+              <input type="email" name="email" required autocomplete="email" />
+            </label>
+            <label>
+              Password
+              <input type="password" name="password" required autocomplete="current-password" />
+            </label>
+            <button type="submit" class="button primary">Sign in</button>
+            <p class="form-hint">Use your BloodVault credentials to continue.</p>
+            <p class="form-error hidden" id="login-error" role="alert"></p>
+          </form>
+        </div>
+        <div class="tab-content" id="register-tab" role="tabpanel" aria-hidden="true">
+          <form id="register-form" class="form-grid">
+            <label>
+              Name
+              <input type="text" name="name" required autocomplete="name" />
+            </label>
+            <label>
+              Email
+              <input type="email" name="email" required autocomplete="email" />
+            </label>
+            <label>
+              Password
+              <input type="password" name="password" required minlength="6" autocomplete="new-password" />
+            </label>
+            <label>
+              Role
+              <select name="usertype" required>
+                <option value="donor">Donor</option>
+                <option value="requester">Requester</option>
+                <option value="admin">Admin</option>
+              </select>
+            </label>
+            <button type="submit" class="button primary">Create account</button>
+            <p class="form-error hidden" id="register-error" role="alert"></p>
+          </form>
+        </div>
+      </section>
+
+      <section id="app-shell" class="app-shell hidden" aria-live="polite">
+        <aside class="sidebar">
+          <div class="user-summary">
+            <p id="user-name" class="user-name">&nbsp;</p>
+            <p id="user-role" class="user-role">&nbsp;</p>
+            <p id="user-email" class="user-email">&nbsp;</p>
+          </div>
+          <nav class="nav-links">
+            <button class="nav-link active" data-section="dashboard">Dashboard</button>
+            <button class="nav-link" data-section="requests">Requests</button>
+            <button class="nav-link" data-section="donations">Donations</button>
+            <button class="nav-link" data-section="appointments">Appointments</button>
+            <button class="nav-link" data-section="inventory">Inventory</button>
+            <button class="nav-link" data-section="profile">Profile</button>
+          </nav>
+        </aside>
+
+        <section class="content">
+          <div id="status-bar" class="status-bar hidden" role="status"></div>
+
+          <section id="dashboard-section" class="content-section active">
+            <h2>Dashboard</h2>
+            <div id="summary-cards" class="summary-cards"></div>
+            <div class="grid two-columns">
+              <div class="card">
+                <div class="section-header">
+                  <h3>Recent Requests</h3>
+                  <button id="dashboard-refresh" class="button button-outline small">Refresh</button>
+                </div>
+                <table class="data-table" id="recent-requests-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Blood type</th>
+                      <th>Units</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+              <div class="card">
+                <h3>Upcoming Appointments</h3>
+                <table class="data-table" id="upcoming-appointments-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Type</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+
+          <section id="requests-section" class="content-section">
+            <div class="section-header">
+              <h2>Blood requests</h2>
+              <button id="refresh-requests" class="button button-outline small">Refresh</button>
+            </div>
+            <div class="card" id="request-form-card">
+              <h3>Create a new request</h3>
+              <form id="create-request-form" class="form-grid">
+                <label>
+                  Blood type
+                  <input type="text" name="bloodType" maxlength="4" placeholder="A+" required />
+                </label>
+                <label>
+                  Units needed
+                  <input type="number" name="unitsNeeded" min="1" step="1" required />
+                </label>
+                <label>
+                  Urgency
+                  <select name="urgency" required>
+                    <option value="low">Low</option>
+                    <option value="medium" selected>Medium</option>
+                    <option value="high">High</option>
+                    <option value="critical">Critical</option>
+                  </select>
+                </label>
+                <label>
+                  Hospital
+                  <input type="text" name="hospital" placeholder="Community Hospital" />
+                </label>
+                <label>
+                  Contact person
+                  <input type="text" name="contactPerson" />
+                </label>
+                <label>
+                  Contact number
+                  <input type="tel" name="contactNumber" />
+                </label>
+                <label class="full-width">
+                  Reason
+                  <textarea name="reason" rows="2" placeholder="Describe the situation"></textarea>
+                </label>
+                <label>
+                  Request date
+                  <input type="date" name="requestDate" />
+                </label>
+                <button type="submit" class="button primary">Submit request</button>
+                <p class="form-error hidden" id="request-error" role="alert"></p>
+              </form>
+            </div>
+            <div class="card">
+              <h3>Existing requests</h3>
+              <table class="data-table" id="requests-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Blood type</th>
+                    <th>Units</th>
+                    <th>Urgency</th>
+                    <th>Status</th>
+                    <th>Available</th>
+                    <th>Allocated units</th>
+                    <th>Requester</th>
+                    <th class="actions-column">Actions</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="donations-section" class="content-section">
+            <div class="section-header">
+              <h2>Blood donations</h2>
+              <button id="refresh-donations" class="button button-outline small">Refresh</button>
+            </div>
+            <div class="card" id="donation-form-card">
+              <h3>Schedule a donation</h3>
+              <form id="create-donation-form" class="form-grid">
+                <label>
+                  Donor name
+                  <input type="text" name="donorName" required />
+                </label>
+                <label>
+                  Donor email
+                  <input type="email" name="donorEmail" required />
+                </label>
+                <label>
+                  Blood type
+                  <input type="text" name="bloodType" maxlength="4" placeholder="O-" required />
+                </label>
+                <label>
+                  Donation date
+                  <input type="date" name="donationDate" />
+                </label>
+                <label>
+                  Quantity (bags)
+                  <input type="number" name="quantity" min="1" step="1" value="1" />
+                </label>
+                <label>
+                  Screening status
+                  <input type="text" name="screeningStatus" placeholder="Pending" />
+                </label>
+                <label class="full-width">
+                  Notes
+                  <textarea name="notes" rows="2" placeholder="Additional information"></textarea>
+                </label>
+                <button type="submit" class="button primary">Submit donation</button>
+                <p class="form-error hidden" id="donation-error" role="alert"></p>
+              </form>
+            </div>
+            <div class="card">
+              <h3>Donation history</h3>
+              <table class="data-table" id="donations-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Blood type</th>
+                    <th>Quantity</th>
+                    <th>Status</th>
+                    <th>Screening</th>
+                    <th>Donor</th>
+                    <th class="actions-column">Actions</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="appointments-section" class="content-section">
+            <div class="section-header">
+              <h2>Appointments</h2>
+              <button id="refresh-appointments" class="button button-outline small">Refresh</button>
+            </div>
+            <div class="card" id="appointment-form-card">
+              <h3>Book an appointment</h3>
+              <form id="create-appointment-form" class="form-grid">
+                <label>
+                  Appointment type
+                  <input type="text" name="appointmentType" placeholder="Donation" required />
+                </label>
+                <label>
+                  Blood type
+                  <input type="text" name="bloodType" maxlength="4" />
+                </label>
+                <label>
+                  Appointment date
+                  <input type="datetime-local" name="appointmentDate" required />
+                </label>
+                <label>
+                  Time slot
+                  <input type="text" name="timeSlot" placeholder="9:00 AM" />
+                </label>
+                <label class="full-width">
+                  Notes
+                  <textarea name="notes" rows="2" placeholder="Anything we should know?"></textarea>
+                </label>
+                <button type="submit" class="button primary">Create appointment</button>
+                <p class="form-error hidden" id="appointment-error" role="alert"></p>
+              </form>
+            </div>
+            <div class="card">
+              <h3>Scheduled appointments</h3>
+              <table class="data-table" id="appointments-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Type</th>
+                    <th>Status</th>
+                    <th>Notes</th>
+                    <th>Participant</th>
+                    <th class="actions-column">Actions</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="inventory-section" class="content-section">
+            <div class="section-header">
+              <h2>Blood bank inventory</h2>
+              <button id="refresh-inventory" class="button button-outline small">Refresh</button>
+            </div>
+            <div class="card">
+              <table class="data-table" id="inventory-table">
+                <thead>
+                  <tr>
+                    <th>Blood type</th>
+                    <th>Quantity</th>
+                    <th>Status</th>
+                    <th>Expires</th>
+                    <th>Donor</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="profile-section" class="content-section">
+            <div class="section-header">
+              <h2>Profile</h2>
+              <button id="refresh-profile" class="button button-outline small">Refresh</button>
+            </div>
+            <div class="card">
+              <dl id="profile-details" class="profile-details"></dl>
+              <div class="profile-actions">
+                <button id="refresh-eligibility" class="button button-outline small">Check donation eligibility</button>
+                <button id="request-verification" class="button small">Send verification email</button>
+              </div>
+              <div id="eligibility-panel" class="eligibility-panel hidden"></div>
+            </div>
+          </section>
+        </section>
+      </section>
+    </main>
+
+    <template id="empty-row-template">
+      <tr><td colspan="9" class="empty">No records available yet.</td></tr>
+    </template>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/node-app/public/styles.css
+++ b/node-app/public/styles.css
@@ -1,0 +1,491 @@
+:root {
+  color-scheme: light dark;
+  --background: #f6f8fb;
+  --surface: #ffffff;
+  --surface-muted: #eef2f8;
+  --border: #d6d9e0;
+  --text-primary: #1d2330;
+  --text-secondary: #5a6275;
+  --primary: #d72638;
+  --primary-dark: #b31c2a;
+  --accent: #2563eb;
+  --success: #0f9d58;
+  --warning: #f59e0b;
+  --danger: #dc2626;
+  --shadow: rgba(15, 23, 42, 0.08);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.app-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 4px 12px var(--shadow);
+}
+
+.app-header .brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-header h1 {
+  font-size: 1.3rem;
+  margin: 0;
+}
+
+.logo {
+  font-size: 1.8rem;
+  filter: drop-shadow(0 2px 4px rgba(215, 38, 56, 0.35));
+}
+
+.main-container {
+  flex: 1;
+  padding: 2rem 1.5rem 3rem;
+  display: grid;
+  justify-content: center;
+}
+
+.auth {
+  max-width: 420px;
+  width: min(100%, 420px);
+  margin: 3rem auto;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 1.5rem;
+  max-width: 1200px;
+  width: 100%;
+}
+
+.sidebar {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 12px 24px var(--shadow);
+}
+
+.user-summary {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: var(--surface-muted);
+  text-align: center;
+}
+
+.user-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+}
+
+.user-role,
+.user-email {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.nav-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.nav-link {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 0.7rem 1rem;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--accent);
+}
+
+.nav-link.active {
+  background: rgba(215, 38, 56, 0.12);
+  color: var(--primary-dark);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.status-bar {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: 0 6px 16px var(--shadow);
+  font-weight: 500;
+}
+
+.status-bar.info {
+  border-color: rgba(37, 99, 235, 0.4);
+  color: var(--accent);
+}
+
+.status-bar.success {
+  border-color: rgba(15, 157, 88, 0.4);
+  color: var(--success);
+}
+
+.status-bar.error {
+  border-color: rgba(220, 38, 38, 0.35);
+  color: var(--danger);
+}
+
+.content-section {
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.content-section.active {
+  display: flex;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 12px 32px var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.summary-cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summary-card {
+  background: var(--surface);
+  border-radius: 0.9rem;
+  border: 1px solid var(--border);
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.summary-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(215, 38, 56, 0.12), rgba(37, 99, 235, 0.08));
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.summary-card strong {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.summary-card span {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.grid.two-columns {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  padding: 0.6rem 0.7rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--border);
+  font: inherit;
+  color: inherit;
+  background: var(--surface-muted);
+}
+
+.form-grid textarea {
+  resize: vertical;
+}
+
+.form-grid .full-width {
+  grid-column: 1 / -1;
+}
+
+.form-hint {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.form-error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 0.85rem;
+}
+
+.button {
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.6rem 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  background: var(--surface-muted);
+  color: var(--text-primary);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px var(--shadow);
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.button.primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  background: var(--primary-dark);
+}
+
+.button.button-outline {
+  background: transparent;
+  border: 1px solid var(--border);
+}
+
+.button.small {
+  font-size: 0.85rem;
+  padding: 0.45rem 0.75rem;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.data-table thead {
+  background: var(--surface-muted);
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.data-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.actions-column {
+  width: 220px;
+}
+
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.actions-cell select,
+.actions-cell input[type='number'],
+.actions-cell input[type='checkbox'] {
+  font: inherit;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  padding: 0.3rem 0.4rem;
+}
+
+.actions-cell .small-input {
+  max-width: 80px;
+}
+
+.actions-cell input[type='checkbox'] {
+  width: auto;
+  padding: 0.3rem;
+}
+
+.profile-details {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(0, 2fr);
+  gap: 0.3rem 1rem;
+  font-size: 0.95rem;
+}
+
+.profile-details dt {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.profile-details dd {
+  margin: 0;
+}
+
+.profile-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.eligibility-panel {
+  padding: 1rem;
+  border-radius: 0.8rem;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 1rem;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab-button {
+  flex: 1;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid transparent;
+  background: var(--surface-muted);
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.tab-button.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .nav-links {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .nav-link {
+    flex: 1 1 45%;
+  }
+}
+
+@media (max-width: 640px) {
+  .main-container {
+    padding: 1rem;
+  }
+
+  .card {
+    padding: 1rem;
+  }
+
+  .actions-column {
+    width: auto;
+  }
+
+  .actions-cell {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
## Summary
- serve the Node API together with a static dashboard, replace PHP templates and apply permissive CORS headers
- add REST endpoints for fetching users, requests, donations, appointments, inventory and dashboard summary data
- build a JavaScript single-page application that consumes the Node API for auth, dashboards and CRUD flows, and document the change in the Node README

## Testing
- npm run lint *(fails: ESLint configuration file is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf2ae611348322a522f1f1bf10aaac