### PR TITLE
Add Railway deployment configuration and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,6 @@ Inside `node-app` the following npm scripts are available:
 
 ## Further reading
 
-Refer to `documentation.md` for a breakdown of the domain features and to
-`setup.md` for a complete environment checklist.
+Refer to `documentation.md` for a breakdown of the domain features, to
+`setup.md` for a complete environment checklist, and to `railway.md` for hosted
+deployment guidance on Railway.

--- a/node-app/.env.example
+++ b/node-app/.env.example
@@ -14,6 +14,14 @@ DB_DATABASE=bloodvault
 DB_USERNAME=root
 DB_PASSWORD=
 
+# Hosted environment fallbacks (Railway, etc.)
+# DATABASE_URL=
+# MYSQLHOST=
+# MYSQLPORT=
+# MYSQLDATABASE=
+# MYSQLUSER=
+# MYSQLPASSWORD=
+
 # Background jobs
 MONGO_URL=mongodb://127.0.0.1/bloodvault-jobs
 AGENDA_PROCESS_EVERY=30 seconds

--- a/node-app/README.md
+++ b/node-app/README.md
@@ -26,7 +26,10 @@ Key variables include database credentials (`DB_HOST`, `DB_DATABASE`,
 `DB_USERNAME`, `DB_PASSWORD`), JWT secrets (`JWT_SECRET`), optional Agenda
 backing store (`MONGO_URL`) and SMTP settings (`MAIL_*`). `APP_ORIGIN` may be set
 to a comma-separated list of allowed front-end origins if the dashboard is
-hosted separately.
+hosted separately. Hosted providers such as Railway expose MySQL credentials via
+`MYSQLHOST`, `MYSQLPORT`, `MYSQLUSER`, `MYSQLPASSWORD` and `MYSQLDATABASE` or a
+`DATABASE_URL` connection string – the database configuration automatically
+recognises these fallbacks.
 
 ## Installing dependencies
 
@@ -73,3 +76,8 @@ npm run lint
   MongoDB is available.
 - Nodemailer defaults to a stream transport when SMTP credentials are not set,
   making local development frictionless.
+
+## Deploying to Railway
+
+See `../railway.md` for detailed hosting instructions, environment variables and
+migration tips tailored to Railway's managed infrastructure.

--- a/node-app/config/database.js
+++ b/node-app/config/database.js
@@ -1,3 +1,4 @@
+import { URL } from 'node:url';
 import { Sequelize } from 'sequelize';
 import dotenv from 'dotenv';
 
@@ -6,21 +7,94 @@ import dotenv from 'dotenv';
 // expects values such as DB_HOST, DB_DATABASE, DB_USERNAME and DB_PASSWORD.
 dotenv.config();
 
-const database = process.env.DB_DATABASE || 'bloodvault';
-const username = process.env.DB_USERNAME || 'root';
-const password = process.env.DB_PASSWORD || '';
-const host = process.env.DB_HOST || '127.0.0.1';
-const dialect = process.env.DB_CONNECTION || 'mysql';
+function normaliseDialect(value, fallback = 'mysql') {
+  if (!value) {
+    return fallback;
+  }
+  const cleaned = value.toString().toLowerCase().replace(/:$/, '');
+  if (cleaned === 'postgresql') {
+    return 'postgres';
+  }
+  if (cleaned === 'mysql2') {
+    return 'mysql';
+  }
+  return cleaned;
+}
 
-export const sequelize = new Sequelize(database, username, password, {
-  host,
-  dialect,
+function defaultPortForDialect(dialect) {
+  switch (dialect) {
+    case 'postgres':
+      return 5432;
+    case 'mssql':
+      return 1433;
+    default:
+      return 3306;
+  }
+}
+
+const fallbackDialect = normaliseDialect(process.env.DB_CONNECTION, 'mysql');
+const baseConfig = {
+  dialect: fallbackDialect,
+  host: process.env.DB_HOST || process.env.MYSQLHOST || '127.0.0.1',
+  port: Number(process.env.DB_PORT || process.env.MYSQLPORT) || defaultPortForDialect(fallbackDialect),
+  database: process.env.DB_DATABASE || process.env.MYSQLDATABASE || 'bloodvault',
+  username: process.env.DB_USERNAME || process.env.MYSQLUSER || 'root',
+  password: process.env.DB_PASSWORD || process.env.MYSQLPASSWORD || ''
+};
+
+const connectionUrl =
+  process.env.DATABASE_URL ||
+  process.env.DB_URL ||
+  process.env.MYSQL_URL ||
+  process.env.CLEARDB_DATABASE_URL ||
+  process.env.JAWSDB_URL ||
+  process.env.JAWSDB_MARIA_URL;
+
+const connectionConfig = { ...baseConfig };
+const dialectOptions = {};
+
+if (connectionUrl) {
+  try {
+    const url = new URL(connectionUrl);
+    const urlDialect = normaliseDialect(url.protocol, connectionConfig.dialect);
+
+    connectionConfig.dialect = normaliseDialect(process.env.DB_CONNECTION, urlDialect);
+    connectionConfig.host = url.hostname || connectionConfig.host;
+    connectionConfig.port = Number(url.port) || connectionConfig.port || defaultPortForDialect(connectionConfig.dialect);
+    connectionConfig.database = url.pathname?.replace(/^\//, '') || connectionConfig.database;
+    connectionConfig.username = url.username ? decodeURIComponent(url.username) : connectionConfig.username;
+    connectionConfig.password = url.password ? decodeURIComponent(url.password) : connectionConfig.password;
+
+    const sslMode = url.searchParams.get('sslmode') || url.searchParams.get('ssl');
+    if (sslMode === 'require' || sslMode === 'true') {
+      dialectOptions.ssl = { require: true, rejectUnauthorized: false };
+    }
+  } catch (error) {
+    console.warn('Failed to parse database connection string. Falling back to discrete credentials.');
+  }
+}
+
+const sequelizeOptions = {
+  host: connectionConfig.host,
+  port: connectionConfig.port,
+  dialect: connectionConfig.dialect,
   logging: false,
   define: {
     underscored: false,
     freezeTableName: true,
     timestamps: true
   }
-});
+};
+
+if (Object.keys(dialectOptions).length > 0) {
+  sequelizeOptions.dialectOptions = dialectOptions;
+}
+
+export const sequelize = new Sequelize(
+  connectionConfig.database,
+  connectionConfig.username,
+  connectionConfig.password,
+  sequelizeOptions
+);
 
 export default sequelize;

--- a/railway.md
+++ b/railway.md
@@ -1,0 +1,106 @@
+# Railway deployment guide
+
+This guide walks through deploying the BloodVault Node.js service to
+[Railway](https://railway.app). The Express API, Socket.IO gateway and dashboard
+live in the `node-app` directory of this repository, so Railway must be pointed
+at that subfolder when building the service.
+
+## 1. Create a Railway project and service
+
+1. Create a new project in the Railway dashboard.
+2. Connect your GitHub repository or use `railway up` from a local clone.
+3. When prompted for the service root directory choose `node-app` (or set the
+   "Root Directory" field to `node-app` in the service settings). Railway's
+   Nixpacks builder will detect the Node application automatically and run
+   `npm install` followed by `npm start`.
+4. Set the service health check path to `/health` so Railway can verify the API
+   is running.
+
+## 2. Provision backing services
+
+* **MySQL** – Add the managed MySQL plugin. The resulting environment variables
+  (`MYSQLHOST`, `MYSQLPORT`, `MYSQLUSER`, `MYSQLPASSWORD`, `MYSQLDATABASE` and
+  the generated connection URL) are consumed automatically by
+  `node-app/config/database.js`.
+* **MongoDB (optional)** – Add the MongoDB plugin if you want Agenda-based
+  background jobs. Copy the provided connection string into the `MONGO_URL`
+  environment variable.
+* **SMTP (optional)** – Configure the `MAIL_*` variables for your preferred mail
+  provider or leave them blank to use Nodemailer's stream transport in
+  development mode.
+
+## 3. Configure environment variables
+
+Create the following variables on the Railway service ("Variables" tab or via
+`railway variables set`):
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `APP_URL` | ✅ | Public URL of the deployed API, e.g. `https://<service>.up.railway.app`. |
+| `APP_ORIGIN` | ✅ | Allowed front-end origins. Use the same value as `APP_URL` unless the dashboard is hosted elsewhere. Multiple origins can be comma separated. |
+| `JWT_SECRET` | ✅ | Random string used to sign authentication tokens. |
+| `DATABASE_URL` | ✅ | (Recommended) Paste the MySQL connection string shown in the plugin's "Connect" panel. This allows CLI tooling to reuse the same URL. |
+| `MONGO_URL` | Optional | Connection string for the MongoDB plugin if Agenda jobs should persist between restarts. |
+| `AGENDA_PROCESS_EVERY` | Optional | Override the Agenda polling cadence (defaults to `30 seconds`). |
+| `MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_ENCRYPTION`, `MAIL_FROM_ADDRESS` | Optional | SMTP credentials for transactional email delivery. |
+
+Railway automatically injects `MYSQLHOST`, `MYSQLPORT`, `MYSQLUSER`,
+`MYSQLPASSWORD` and `MYSQLDATABASE` when the MySQL plugin is attached, so no
+additional mapping is required. The application will fall back to those
+variables if `DATABASE_URL` is not defined.
+
+A template environment group for Railway might look like:
+
+```
+APP_URL=https://your-service.up.railway.app
+APP_ORIGIN=https://your-service.up.railway.app
+JWT_SECRET=generate-a-long-random-string
+DATABASE_URL=mysql://user:password@containers-us-west-123.railway.app:3306/railway
+MONGO_URL=
+AGENDA_PROCESS_EVERY=30 seconds
+MAIL_HOST=
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_ENCRYPTION=
+MAIL_FROM_ADDRESS=no-reply@bloodvault.local
+```
+
+## 4. Run the database migrations
+
+After the service is linked to Railway run the Sequelize migrations against the
+managed MySQL instance:
+
+```bash
+# Authenticate once if you have not already
+railway login
+
+# Link the local checkout to the Railway project
+railway link
+
+# Execute the migrations using the environment variables from Railway
+railway run --service <service-name> -- npx --yes sequelize-cli db:migrate \
+  --migrations-path node-app/migrations \
+  --url "$DATABASE_URL"
+```
+
+Replace `<service-name>` with the name of the deployed Node service. The
+`--yes` flag prevents `npx` from prompting during CI/CD runs. You can also run
+this command from the Railway dashboard by starting a one-off shell and executing
+`npx sequelize-cli db:migrate --migrations-path migrations --url "$DATABASE_URL"`
+from the `node-app` directory.
+
+## 5. Deploy and verify
+
+Trigger a deployment from the Railway dashboard (or push to the connected Git
+branch). Once the build completes, Railway will expose the service at
+`https://<service>.up.railway.app` (or your custom domain). Visit
+`/health` to verify the API responds:
+
+```
+https://<service>.up.railway.app/health
+```
+
+If you later attach a custom domain remember to update `APP_URL` and
+`APP_ORIGIN` accordingly. Socket.IO will automatically use the same origin as
+long as CORS stays aligned with these variables.

--- a/setup.md
+++ b/setup.md
@@ -63,3 +63,8 @@ same port. Use `npm start` for a production configuration.
   on a different domain.
 - If MongoDB is available the scheduled tasks defined with Agenda will persist
   across restarts.
+
+## Hosted deployment
+
+Deploying to Railway? Follow the step-by-step instructions in `railway.md` for
+service provisioning, environment configuration and migration tips.


### PR DESCRIPTION
## Summary
- normalise database configuration to accept Railway-provided connection strings and credential variables
- extend environment examples and documentation to point to hosted deployment fallbacks
- add a dedicated Railway deployment guide and cross-link it from existing docs

## Testing
- npm install *(fails: registry returned HTTP 403 for agenda package)*
- npm run lint *(fails: ESLint 9 expects eslint.config.js; repository currently lacks the new-format config)*

------
https://chatgpt.com/codex/tasks/task_e_68cf414e05f0832282f4b848cad8c363