### PR TITLE
Add sequelize CLI configuration using shared environment parsing

### DIFF
--- a/node-app/.sequelizerc
+++ b/node-app/.sequelizerc
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = {
+  config: path.resolve(__dirname, 'config', 'config.cjs'),
+  migrationsPath: path.resolve(__dirname, 'migrations')
+};

--- a/node-app/config/config.cjs
+++ b/node-app/config/config.cjs
@@ -1,0 +1,92 @@
+const { URL } = require('node:url');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+function normaliseDialect(value, fallback = 'mysql') {
+  if (!value) {
+    return fallback;
+  }
+  const cleaned = value.toString().toLowerCase().replace(/:$/, '');
+  if (cleaned === 'postgresql') {
+    return 'postgres';
+  }
+  if (cleaned === 'mysql2') {
+    return 'mysql';
+  }
+  return cleaned;
+}
+
+function defaultPortForDialect(dialect) {
+  switch (dialect) {
+    case 'postgres':
+      return 5432;
+    case 'mssql':
+      return 1433;
+    default:
+      return 3306;
+  }
+}
+
+const fallbackDialect = normaliseDialect(process.env.DB_CONNECTION, 'mysql');
+const baseConfig = {
+  dialect: fallbackDialect,
+  host: process.env.DB_HOST || process.env.MYSQLHOST || '127.0.0.1',
+  port: Number(process.env.DB_PORT || process.env.MYSQLPORT) || defaultPortForDialect(fallbackDialect),
+  database: process.env.DB_DATABASE || process.env.MYSQLDATABASE || 'bloodvault',
+  username: process.env.DB_USERNAME || process.env.MYSQLUSER || 'root',
+  password: process.env.DB_PASSWORD || process.env.MYSQLPASSWORD || ''
+};
+
+const connectionUrl =
+  process.env.DATABASE_URL ||
+  process.env.DB_URL ||
+  process.env.MYSQL_URL ||
+  process.env.CLEARDB_DATABASE_URL ||
+  process.env.JAWSDB_URL ||
+  process.env.JAWSDB_MARIA_URL;
+
+const connectionConfig = { ...baseConfig };
+const dialectOptions = {};
+
+if (connectionUrl) {
+  try {
+    const url = new URL(connectionUrl);
+    const urlDialect = normaliseDialect(url.protocol, connectionConfig.dialect);
+
+    connectionConfig.dialect = normaliseDialect(process.env.DB_CONNECTION, urlDialect);
+    connectionConfig.host = url.hostname || connectionConfig.host;
+    connectionConfig.port =
+      Number(url.port) || connectionConfig.port || defaultPortForDialect(connectionConfig.dialect);
+    connectionConfig.database = url.pathname ? url.pathname.replace(/^\//, '') : connectionConfig.database;
+    connectionConfig.username = url.username ? decodeURIComponent(url.username) : connectionConfig.username;
+    connectionConfig.password = url.password ? decodeURIComponent(url.password) : connectionConfig.password;
+
+    const sslMode = url.searchParams.get('sslmode') || url.searchParams.get('ssl');
+    if (sslMode === 'require' || sslMode === 'true') {
+      dialectOptions.ssl = { require: true, rejectUnauthorized: false };
+    }
+  } catch (error) {
+    console.warn('Failed to parse database connection string. Falling back to discrete credentials.');
+  }
+}
+
+const finalConfig = {
+  ...connectionConfig,
+  logging: false,
+  define: {
+    underscored: false,
+    freezeTableName: true,
+    timestamps: true
+  }
+};
+
+if (Object.keys(dialectOptions).length > 0) {
+  finalConfig.dialectOptions = dialectOptions;
+}
+
+module.exports = {
+  development: { ...finalConfig },
+  test: { ...finalConfig },
+  production: { ...finalConfig }
+};


### PR DESCRIPTION
## Summary
- add a CommonJS configuration for sequelize-cli that mirrors the runtime database parsing logic
- point sequelize-cli at the new configuration and local migrations directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf988565e88322a0705cf530087e6c