### PR TITLE
Fix sequelize-cli migration loading error

### DIFF
--- a/node-app/migrations/001-create-users-table.js
+++ b/node-app/migrations/001-create-users-table.js
@@ -4,7 +4,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('users', {
     USER_ID: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -82,6 +82,8 @@ export async function up(queryInterface, Sequelize) {
   });
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('users');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/002-add-email-verification-to-users.js
+++ b/node-app/migrations/002-add-email-verification-to-users.js
@@ -4,7 +4,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.addColumn('users', 'email_verified_at', {
     type: Sequelize.DATE,
     allowNull: true
@@ -21,8 +21,10 @@ export async function up(queryInterface, Sequelize) {
   });
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.removeColumn('users', 'email_verified_at');
   await queryInterface.removeColumn('users', 'email_verification_token');
   await queryInterface.removeColumn('users', 'is_verified');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/003-create-screenings-table.js
+++ b/node-app/migrations/003-create-screenings-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('screenings', {
     SCREENING_ID: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -36,6 +36,8 @@ export async function up(queryInterface, Sequelize) {
   });
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('screenings');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/004-create-requests-table.js
+++ b/node-app/migrations/004-create-requests-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('requests', {
     RESERVATION_ID: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -46,6 +46,8 @@ export async function up(queryInterface, Sequelize) {
   });
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('requests');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/005-create-blood-banks-table.js
+++ b/node-app/migrations/005-create-blood-banks-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('blood_banks', {
     STOCK_ID: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -57,6 +57,8 @@ export async function up(queryInterface, Sequelize) {
   await queryInterface.addIndex('blood_banks', ['blood_type']);
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('blood_banks');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/006-create-blood-requests-table.js
+++ b/node-app/migrations/006-create-blood-requests-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('blood_requests', {
     id: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -94,6 +94,8 @@ export async function up(queryInterface, Sequelize) {
   await queryInterface.addIndex('blood_requests', ['request_date']);
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('blood_requests');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/007-modify-allocated-units-on-blood-requests.js
+++ b/node-app/migrations/007-modify-allocated-units-on-blood-requests.js
@@ -5,7 +5,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.changeColumn('blood_requests', 'allocated_units', {
     type: Sequelize.INTEGER,
     allowNull: true,
@@ -13,10 +13,12 @@ export async function up(queryInterface, Sequelize) {
   });
 }
 
-export async function down(queryInterface, Sequelize) {
+async function down(queryInterface, Sequelize) {
   await queryInterface.changeColumn('blood_requests', 'allocated_units', {
     type: Sequelize.INTEGER,
     allowNull: false,
     defaultValue: 0
   });
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/008-create-email-verifications-table.js
+++ b/node-app/migrations/008-create-email-verifications-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('email_verifications', {
     id: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -45,6 +45,8 @@ export async function up(queryInterface, Sequelize) {
   await queryInterface.addIndex('email_verifications', ['used']);
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('email_verifications');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/009-create-blood-donations-table.js
+++ b/node-app/migrations/009-create-blood-donations-table.js
@@ -5,7 +5,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('blood_donations', {
     id: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -67,6 +67,8 @@ export async function up(queryInterface, Sequelize) {
   await queryInterface.addIndex('blood_donations', ['donation_date']);
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('blood_donations');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/010-add-missing-fields-to-blood-donations.js
+++ b/node-app/migrations/010-add-missing-fields-to-blood-donations.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.addColumn('blood_donations', 'admin_notes', {
     type: Sequelize.TEXT,
     allowNull: true
@@ -19,8 +19,10 @@ export async function up(queryInterface, Sequelize) {
   });
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.removeColumn('blood_donations', 'admin_notes');
   await queryInterface.removeColumn('blood_donations', 'quantity');
   await queryInterface.removeColumn('blood_donations', 'screening_status');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/011-create-appointments-table.js
+++ b/node-app/migrations/011-create-appointments-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('appointments', {
     id: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -62,6 +62,8 @@ export async function up(queryInterface, Sequelize) {
   await queryInterface.addIndex('appointments', ['appointment_type']);
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('appointments');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/012-add-blood-type-to-appointments.js
+++ b/node-app/migrations/012-add-blood-type-to-appointments.js
@@ -3,13 +3,15 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.addColumn('appointments', 'blood_type', {
     type: Sequelize.STRING(4),
     allowNull: true
   });
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.removeColumn('appointments', 'blood_type');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/013-create-password-resets-table.js
+++ b/node-app/migrations/013-create-password-resets-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('password_resets', {
     email: {
       type: Sequelize.STRING(255),
@@ -22,6 +22,8 @@ export async function up(queryInterface, Sequelize) {
   await queryInterface.addIndex('password_resets', ['email']);
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('password_resets');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/014-create-failed-jobs-table.js
+++ b/node-app/migrations/014-create-failed-jobs-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('failed_jobs', {
     id: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -40,6 +40,8 @@ export async function up(queryInterface, Sequelize) {
   });
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('failed_jobs');
 }
+
+module.exports = { up, down };

--- a/node-app/migrations/015-create-personal-access-tokens-table.js
+++ b/node-app/migrations/015-create-personal-access-tokens-table.js
@@ -3,7 +3,7 @@
  * @param {import('sequelize').QueryInterface} queryInterface
  * @param {typeof import('sequelize').Sequelize} Sequelize
  */
-export async function up(queryInterface, Sequelize) {
+async function up(queryInterface, Sequelize) {
   await queryInterface.createTable('personal_access_tokens', {
     id: {
       type: Sequelize.BIGINT.UNSIGNED,
@@ -55,6 +55,8 @@ export async function up(queryInterface, Sequelize) {
   await queryInterface.addIndex('personal_access_tokens', ['token']);
 }
 
-export async function down(queryInterface) {
+async function down(queryInterface) {
   await queryInterface.dropTable('personal_access_tokens');
 }
+
+module.exports = { up, down };


### PR DESCRIPTION
## Summary
- convert all migrations to CommonJS-style exports so sequelize-cli can load them under Node.js
- retain the existing migration logic while adding shared module.exports blocks to expose up/down functions

## Testing
- npm run lint *(fails: ESLint configuration file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9e7c2b948322b7fcd79472df1d42