### PR TITLE
Fix sequelize CLI migrations in production

### DIFF
--- a/node-app/migrations/package.json
+++ b/node-app/migrations/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- ensure the migrations directory is treated as CommonJS so sequelize-cli can require migration files even when the app uses ESM

## Testing
- npm run lint *(fails: ESLint configuration is missing in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d0834350ac8322aa03d5e12c23efb4