### PR TITLE
Handle missing Mongo scheduler configuration

### DIFF
--- a/node-app/app.js
+++ b/node-app/app.js
@@ -66,8 +66,16 @@ app.use(bodyParser.json({ limit: '1mb' }));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static(pagesDir));
 
+const schedulerMongoUrl =
+  process.env.AGENDA_MONGO_URL ||
+  process.env.MONGO_URL ||
+  process.env.MONGODB_URI ||
+  process.env.MONGODB_URL ||
+  process.env.MONGO_CONNECTION_STRING ||
+  null;
+
 const scheduler = createScheduler({
-  mongoUrl: process.env.MONGO_URL || 'mongodb://127.0.0.1/bloodvault-jobs',
+  mongoUrl: schedulerMongoUrl,
   processEvery: process.env.AGENDA_PROCESS_EVERY || '30 seconds',
   disabled: toBoolean(process.env.AGENDA_DISABLED)
 });


### PR DESCRIPTION
## Summary
- stop defaulting the agenda scheduler to a localhost MongoDB instance and honour only provided connection strings
- harden the scheduler helper to treat missing configuration as disabled and fall back to inline execution when connection errors occur

## Testing
- npm run lint *(fails: ESLint configuration file is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d09895bcc0832290b87c8f2a1cf10a