### PR TITLE
Align Sequelize timestamp column names with database schema

### DIFF
--- a/node-app/config/database.js
+++ b/node-app/config/database.js
@@ -80,9 +80,11 @@ const sequelizeOptions = {
   dialect: connectionConfig.dialect,
   logging: false,
   define: {
-    underscored: false,
+    underscored: true,
     freezeTableName: true,
-    timestamps: true
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at'
   }
 };
 


### PR DESCRIPTION
## Summary
- configure the shared Sequelize options to use underscored column names
- explicitly map createdAt and updatedAt to the database's created_at/updated_at columns

## Testing
- npm run lint *(fails: ESLint configuration file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1fc2766c083228931a655ea4d773b